### PR TITLE
Descent parser internal refactoring for upcoming work

### DIFF
--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
@@ -6,10 +6,12 @@ import com.mmm.his.cer.utility.farser.ast.node.operator.Not;
 import com.mmm.his.cer.utility.farser.ast.node.operator.Or;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.node.type.NodeSupplier;
+import com.mmm.his.cer.utility.farser.lexer.CommonTokenType;
 import com.mmm.his.cer.utility.farser.lexer.FarserException;
+import com.mmm.his.cer.utility.farser.lexer.TokenType;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgFormulaToken;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.ListIterator;
 import java.util.Map;
@@ -24,7 +26,6 @@ import java.util.Map;
  */
 public class DescentParser<T> {
 
-  private BooleanExpression<T> root;
   private DrgLexerToken currentToken;
   private Iterator<DrgLexerToken> tokenIterator;
   private final NodeSupplier<DrgLexerToken, T> defaultSupplier;
@@ -33,28 +34,31 @@ public class DescentParser<T> {
   /**
    * Ctor.
    *
-   * @param tokenIterator   list of tokens to parse into the Abstract syntax tree.
+   * @param tokenIterator   list of tokens to parse into the Abstract syntax tree. May be
+   *                        <code>null</code>.
    * @param defaultSupplier a factory which creates nodes for the tree. This supplier is used by
    *                        default when <code>suppliers</code> does not contain a node specific
    *                        supplier
    * @param suppliers       A map with node suppliers specific to certain tokens (token value as map
-   *                        key)
+   *                        key). May be <code>null</code>.
    */
   public DescentParser(Iterator<DrgLexerToken> tokenIterator,
       NodeSupplier<DrgLexerToken, T> defaultSupplier,
       Map<String, NodeSupplier<DrgLexerToken, T>> suppliers) {
     this.tokenIterator = tokenIterator;
-    this.currentToken = tokenIterator.next();
+    this.currentToken = tokenIterator != null ? tokenIterator.next() : null;
     if (defaultSupplier == null) {
       throw new FarserException(
-          "Please provide at least a default supplier argument to DescentParser constructor");
+          "Please provide at least a default supplier argument to "
+              + DescentParser.class.getSimpleName()
+              + " constructor");
     }
     this.defaultSupplier = defaultSupplier;
 
     // If there is no map, instantiate new map to avoid NPEs. If nothing is in the map the
     // defaultSupplier takes over.
     if (suppliers == null) {
-      this.suppliers = new HashMap<>();
+      this.suppliers = Collections.emptyMap();
     } else {
       this.suppliers = suppliers;
     }
@@ -73,63 +77,85 @@ public class DescentParser<T> {
    * Build the abstract syntax tree.
    */
   public DrgSyntaxTree<T> buildExpressionTree() {
-    expression();
-    return this.getAst();
+    BooleanExpression<T> root = expression(null);
+    return new DrgSyntaxTree<>(root);
+  }
+
+  /**
+   * Build the abstract syntax tree from the provided formula/tokens.
+   *
+   * @param tokenIterator list of tokens to parse into the Abstract syntax tree.
+   */
+  public DrgSyntaxTree<T> buildExpressionTree(ListIterator<DrgLexerToken> tokenIterator) {
+    setTokenIterator(tokenIterator);
+    BooleanExpression<T> root = expression(null);
+    return new DrgSyntaxTree<>(root);
   }
 
   /**
    * Expression method which will build the OR after parsing a term.
    */
-  private void expression() {
-    term();
-    while (currentToken.getType() == DrgFormulaToken.OR) {
-      this.eat(DrgFormulaToken.OR);
+  private BooleanExpression<T> expression(BooleanExpression<T> root) {
+    root = term(root);
+    TokenType<?> tokenType;
+    while ((tokenType = currentToken.getType()) == DrgFormulaToken.OR) {
+      this.eat(tokenType); // Move iterator if 'OR'
       Or<T> or = new Or<>();
       or.setLeft(root);
-      term();
+      root = term(root);
       or.setRight(root);
       root = or;
     }
+    return root;
   }
 
   /**
    * Term method which will build the AND after parsing the factors or operands.
    */
-  private void term() {
-    factor();
-    while (currentToken.getType() == DrgFormulaToken.AND) {
-      this.eat(DrgFormulaToken.AND);
+  private BooleanExpression<T> term(BooleanExpression<T> root) {
+    root = factor(root);
+    TokenType<?> tokenType;
+    while ((tokenType = currentToken.getType()) == DrgFormulaToken.AND) {
+      this.eat(tokenType); // Move iterator if 'AND'
       And<T> and = new And<>();
       and.setLeft(root);
-      factor();
+      root = factor(root);
       and.setRight(root);
       root = and;
     }
+    return root;
   }
 
   /**
    * Factor out a single the operands.
    */
-  private void factor() {
-    if (currentToken.getType() == DrgFormulaToken.ATOM) {
-
+  private BooleanExpression<T> factor(BooleanExpression<T> root) {
+    TokenType<?> tokenType = currentToken.getType();
+    // Get common type for generic checking. Ok to return 'null', only used in NPE safe logic.
+    CommonTokenType commonType = tokenType.getCommonTokenType().orElse(null);
+    if (commonType == CommonTokenType.ATOM) {
       NodeSupplier<DrgLexerToken, T> nodeSupplier = suppliers.getOrDefault(
           currentToken.value, defaultSupplier);
       root = nodeSupplier.createNode(currentToken);
-      this.eat(DrgFormulaToken.ATOM);
-    } else if (currentToken.getType() == DrgFormulaToken.LPAREN) {
-      this.eat(DrgFormulaToken.LPAREN);
-      this.expression();
-      this.eat(DrgFormulaToken.RPAREN);
-    } else if (currentToken.getType() == DrgFormulaToken.NOT) {
-      this.eat(DrgFormulaToken.NOT);
+      this.eat(tokenType); // Move iterator if 'ATOM'
+    } else if (commonType == CommonTokenType.LPAREN) {
+      this.eat(tokenType); // Move iterator if 'LPAREN'
+      root = this.expression(root);
+      TokenType<?> rightParen =
+          TokenType.getForCommonTypeMandatory(tokenType.getClass(), CommonTokenType.RPAREN);
+      this.eat(rightParen); // Move iterator if 'RPAREN'
+    } else if (commonType == CommonTokenType.NOT) {
+      this.eat(tokenType); // Move iterator if 'NOT'
       Not<T> not = new Not<>();
-      factor();
+      root = factor(root);
       not.setChild(root);
       root = not;
     } else {
-      throw new FarserException("Expression malformed on token " + currentToken);
+      throw new FarserException("Expression malformed on token "
+          + currentToken);
     }
+
+    return root;
   }
 
   /**
@@ -137,18 +163,10 @@ public class DescentParser<T> {
    *
    * @param type the type of the token to eat.
    */
-  private void eat(DrgFormulaToken type) {
-    if (currentToken.getType() == type && this.tokenIterator.hasNext()) {
+  private void eat(TokenType<?> type) {
+    if ((currentToken.getType() == type) && this.tokenIterator.hasNext()) {
       currentToken = this.tokenIterator.next();
     }
   }
 
-  /**
-   * Helper method that creates a new {@link DrgSyntaxTree} from the root.
-   *
-   * @return new DrgSyntaxTree
-   */
-  private DrgSyntaxTree<T> getAst() {
-    return new DrgSyntaxTree<>(this.root);
-  }
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/parser/DescentParser.java
@@ -131,7 +131,8 @@ public class DescentParser<T> {
    */
   private BooleanExpression<T> factor(BooleanExpression<T> root) {
     TokenType<?> tokenType = currentToken.getType();
-    // Get common type for generic checking. Ok to return 'null', only used in NPE safe logic.
+    // Get common type for generic checking. Ok to return 'null', it is only used in NPE safe logic
+    // below.
     CommonTokenType commonType = tokenType.getCommonTokenType().orElse(null);
     if (commonType == CommonTokenType.ATOM) {
       NodeSupplier<DrgLexerToken, T> nodeSupplier = suppliers.getOrDefault(


### PR DESCRIPTION
Internal methods with less side-effects. Instead of updating the internal `BooleanExpression<T> root` field from the various methods, the data is now passed through as method input and output.

The method `factor` now checks against the `CommonTokenType`. This is one step towards making the descent parser non-DRG specific (see upcoming PR).

A few small updates and documentation in constructor.

This helps (in my opinion) to understand the flow of the logic, specifically with the nested nature of this implementation. Some refactoring is done in upcoming PRs for which the changes here were very helpful.