### PR TITLE
Abstract Syntax Tree iteration implemented

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,10 @@ which means that walking through the tree can be achieved by retrieving an itera
 evaluation of the formulas where the left-side nodes are visited/evaluated first. When each node 
 is printed as text in iteration order, it produces a "Polish/prefix notation" form of the formula.
 
+The used `LtrExpressionIterator` also implements "peeking" functionality to look at the next 
+element with the `peek()` method without advancing the regular iteration. Additionally, the 
+`LtrExpressionIterator` provides methods which return the current and peeked node "depth".
+
 The formula `A & B | C` is iterated as `"OR" -> "AND"-> "A"-> "B"-> "C"`, which could be 
 organized as a tree structure like this:
 

--- a/readme.md
+++ b/readme.md
@@ -244,6 +244,39 @@ vary. The used context can get accessed with `ExpressionResult#getContext()`. Th
 updated during the evaluation to provide further information about the evaluation.
 
 
+#### Abstract Syntax Tree Iteration
+
+The `AbstractSyntaxTree` (and `DrgSyntaxTree`, plus any of the AST nodes) implement `Iterable`, 
+which means that walking through the tree can be achieved by retrieving an iterator and calling 
+`next` on it. The iteration follows the LTR (left-to-right) approach, the same as the 
+evaluation of the formulas where the left-side nodes are visited/evaluated first. When each node 
+is printed as text in iteration order, it produces a "Polish/prefix notation" form of the formula.
+
+The formula `A & B | C` is iterated as `"OR" -> "AND"-> "A"-> "B"-> "C"`, which could be 
+organized as a tree structure like this:
+
+```text
+OR
+ |-AND
+ |  |-A
+ |  \-B
+ \-C
+```
+
+Related code example:
+
+```java
+DescentParser<MaskedContext<String>> parser = ...;
+AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+while (iter.hasNext()) {
+  String print = iter.next().print();
+  System.out.println(print);
+}
+```
+
+
 #### Abstract Syntax Tree Examples
 
 The following diagrams are a visual representation of the AST after it was parsed by the descent parser.

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
@@ -31,7 +31,12 @@ public class AbstractSyntaxTree<C> extends NonTerminal<C> {
 
   @Override
   public LtrExpressionIterator<C> iterator() {
-    return this.ast.iterator();
+    return new LtrExpressionIterator<>(ast);
+  }
+
+  @Override
+  public String print() {
+    return this.ast.print();
   }
 
   /**

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
@@ -1,7 +1,7 @@
 package com.mmm.his.cer.utility.farser.ast;
 
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
-import com.mmm.his.cer.utility.farser.ast.node.type.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
 import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
@@ -1,6 +1,7 @@
 package com.mmm.his.cer.utility.farser.ast;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
 import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
 
@@ -26,6 +27,11 @@ public class AbstractSyntaxTree<C> extends NonTerminal<C> {
   @Override
   public boolean evaluate(C context) {
     return this.ast.evaluate(context);
+  }
+
+  @Override
+  public LtrExpressionIterator<C> iterator() {
+    return this.ast.iterator();
   }
 
   /**

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
@@ -50,7 +50,7 @@ public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> 
   public int getCurrentDepth() {
     // If peeked, do not return the depth of the latest (peeked) element. Return the depth of the
     // one before.
-    if (peeked != null) {
+    if (depthBeforePeek != null) {
       return depthBeforePeek;
     }
 
@@ -113,7 +113,7 @@ public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> 
    * @return The next element in the iteration
    */
   public BooleanExpression<C> peek() {
-    // Only re-peek if not already peeked.
+    // Only peek if not already peeked.
     if (peeked == null) {
       depthBeforePeek = getCurrentDepthInternal();
       peeked = nextInternal();

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
@@ -1,5 +1,6 @@
-package com.mmm.his.cer.utility.farser.ast.node.type;
+package com.mmm.his.cer.utility.farser.ast.node;
 
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import java.util.Arrays;
 import java.util.Iterator;
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
@@ -13,6 +13,7 @@ public class And<C> extends NonTerminal<C> {
 
   @Override
   public boolean evaluate(C context) {
+    // Evaluate left-side first, then right-side
     return left.evaluate(context) && right.evaluate(context);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
@@ -13,6 +13,7 @@ public class Or<C> extends NonTerminal<C> {
 
   @Override
   public boolean evaluate(C context) {
+    // Evaluate left-side first, then right-side
     return left.evaluate(context) || right.evaluate(context);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
@@ -1,13 +1,14 @@
 package com.mmm.his.cer.utility.farser.ast.node.terminal;
 
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.LtrExpressionIterator;
 import java.util.Collection;
 
 /**
  * A terminal node that represents an evaluation that centers around the list#contains. This node
  * will check the incoming values to see if the field value is contained with in it.
  *
- * @param <C> The node context type this node.
+ * @param <C> The type used in the terminal nodes.
  * @author Mike Funaro
  */
 public class ContainsNode<C extends Collection<A>, A> implements BooleanExpression<C> {
@@ -21,6 +22,17 @@ public class ContainsNode<C extends Collection<A>, A> implements BooleanExpressi
   @Override
   public boolean evaluate(C context) {
     return context.contains(this.value);
+  }
+
+  @Override
+  public LtrExpressionIterator<C> iterator() {
+    // Terminal node. Nothing to iterate over further.
+    return new LtrExpressionIterator<>();
+  }
+
+  @Override
+  public String print() {
+    return String.valueOf(value);
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
@@ -1,7 +1,7 @@
 package com.mmm.his.cer.utility.farser.ast.node.terminal;
 
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
-import com.mmm.his.cer.utility.farser.ast.node.type.LtrExpressionIterator;
 import java.util.Collection;
 
 /**

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
@@ -4,11 +4,11 @@ package com.mmm.his.cer.utility.farser.ast.node.type;
  * Interface for each node of the AST to implement. This will allow the evaluation of the entire
  * boolean expression through recursion.
  *
- * @param <C> The type of context to be used for the terminal node execution.
+ * @param <T> The type of context to be used for the terminal node execution.
  *
  * @author Mike Funaro
  */
-public interface BooleanExpression<C> {
+public interface BooleanExpression<T> extends Iterable<BooleanExpression<T>> {
 
   /**
    * Evaluate an expression returning true or false based on tests against the operands sent in.
@@ -16,6 +16,26 @@ public interface BooleanExpression<C> {
    * @param context The context that will be used in the evaluation of the node.
    * @return <code>true</code> or <code>false</code>.
    */
-  boolean evaluate(C context);
+  boolean evaluate(T context);
+
+  /**
+   * Returns an iterator over the expression elements.<br>
+   * <br>
+   * For terminal nodes, <code>null</code> should not be returned but an empty iterator can be
+   * returned (<code>return new ExpressionIterator<>(this)</code> - this default implementation).
+   */
+  @Override
+  default LtrExpressionIterator<T> iterator() {
+    return new LtrExpressionIterator<>();
+  }
+
+  /**
+   * Returns a printable representation of the node.
+   *
+   * @return The printable form of this node
+   */
+  default String print() {
+    return toString();
+  }
 
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
@@ -1,5 +1,7 @@
 package com.mmm.his.cer.utility.farser.ast.node.type;
 
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
+
 /**
  * Interface for each node of the AST to implement. This will allow the evaluation of the entire
  * boolean expression through recursion.

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
@@ -24,7 +24,7 @@ public interface BooleanExpression<T> extends Iterable<BooleanExpression<T>> {
    * Returns an iterator over the expression elements.<br>
    * <br>
    * For terminal nodes, <code>null</code> should not be returned but an empty iterator can be
-   * returned (<code>return new ExpressionIterator<>(this)</code> - this default implementation).
+   * returned (<code>return new ExpressionIterator<>()</code> - this default implementation).
    */
   @Override
   default LtrExpressionIterator<T> iterator() {

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
@@ -6,11 +6,11 @@ import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
  * Interface for each node of the AST to implement. This will allow the evaluation of the entire
  * boolean expression through recursion.
  *
- * @param <T> The type of context to be used for the terminal node execution.
+ * @param <C> The type of context to be used for the terminal node execution.
  *
  * @author Mike Funaro
  */
-public interface BooleanExpression<T> extends Iterable<BooleanExpression<T>> {
+public interface BooleanExpression<C> extends Iterable<BooleanExpression<C>> {
 
   /**
    * Evaluate an expression returning true or false based on tests against the operands sent in.
@@ -18,7 +18,7 @@ public interface BooleanExpression<T> extends Iterable<BooleanExpression<T>> {
    * @param context The context that will be used in the evaluation of the node.
    * @return <code>true</code> or <code>false</code>.
    */
-  boolean evaluate(T context);
+  boolean evaluate(C context);
 
   /**
    * Returns an iterator over the expression elements.<br>
@@ -27,7 +27,7 @@ public interface BooleanExpression<T> extends Iterable<BooleanExpression<T>> {
    * returned (<code>return new ExpressionIterator<>()</code> - this default implementation).
    */
   @Override
-  default LtrExpressionIterator<T> iterator() {
+  default LtrExpressionIterator<C> iterator() {
     return new LtrExpressionIterator<>();
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/LtrExpressionIterator.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/LtrExpressionIterator.java
@@ -1,0 +1,134 @@
+package com.mmm.his.cer.utility.farser.ast.node.type;
+
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * An iterator which iterates over the complete expression, top down (starting at the root node) and
+ * from "left to right" (LTR - in the order of the formula evaluation). The order of the elements it
+ * iterates over produces a "Polish/prefix notation" of the formula when printed out in this
+ * iteration order.
+ *
+ * @author Thomas Naeff
+ *
+ * @param <C> The expression context data type
+ */
+public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> {
+
+  /**
+   * The value returned by {@link #getPeekedDepth()} if {@link #peek()} has not been called yet.
+   */
+  public static final int PEEKED_DEPTH_NONE = -1;
+
+  private final Iterator<BooleanExpression<C>> nodes;
+  private final int currentDepth;
+  private Integer depthBeforePeek = null;
+  private LtrExpressionIterator<C> currentIterator;
+  private BooleanExpression<C> peeked = null;
+
+  private LtrExpressionIterator(int depth, Iterator<BooleanExpression<C>> nodes) {
+    this.currentDepth = depth;
+    this.nodes = nodes;
+  }
+
+  private LtrExpressionIterator(int depth, LtrExpressionIterator<C> copy) {
+    this(depth, copy.nodes);
+  }
+
+  @SafeVarargs
+  public LtrExpressionIterator(BooleanExpression<C>... nodes) {
+    this(0, Arrays.asList(nodes).iterator());
+  }
+
+  /**
+   * The depth of the current node in this iterator (the last node that was returned with
+   * {@link #next()}).
+   *
+   * @return The depth of the current node in the tree. The root node is <code>0</code>.
+   */
+  public int getCurrentDepth() {
+    // If peeked, do not return the depth of the latest (peeked) element. Return the depth of the
+    // one before.
+    if (peeked != null) {
+      return depthBeforePeek;
+    }
+
+    return getCurrentDepthInternal();
+  }
+
+  private int getCurrentDepthInternal() {
+    if (currentIterator != null) {
+      return currentIterator.getCurrentDepth();
+    }
+    return currentDepth;
+  }
+
+  @Override
+  public boolean hasNext() {
+    // If already advanced due to 'peek', we know it has a next one.
+    if (peeked != null) {
+      return true;
+    }
+    return nodes.hasNext()
+        || ((currentIterator != null) && currentIterator.hasNext());
+  }
+
+  @Override
+  public BooleanExpression<C> next() {
+    // Only advance if not already done so by 'peek' for example.
+    if (peeked == null) {
+      return nextInternal();
+    } else {
+      BooleanExpression<C> tmp = peeked;
+      // Reset, to continue normal.
+      peeked = null;
+      depthBeforePeek = null;
+      return tmp;
+    }
+  }
+
+  private BooleanExpression<C> nextInternal() {
+    if ((currentIterator != null) && currentIterator.hasNext()) {
+      // Iterate down the tree first
+      return currentIterator.next();
+    } else {
+      // Iterator is used up. Continue with top level iteration.
+      currentIterator = null;
+    }
+
+    BooleanExpression<C> current = nodes.next();
+
+    // Keep node iterator for later to iterate down the tree.
+    currentIterator = new LtrExpressionIterator<>(currentDepth + 1, current.iterator());
+
+    return current;
+  }
+
+  /**
+   * Peeks at the next element in the iteration, but does not advance the state of this
+   * iterator.<br>
+   * A subsequent call to {@link #next()} or {@link #peek()} will return the exact same item.
+   *
+   * @return The next element in the iteration
+   */
+  public BooleanExpression<C> peek() {
+    // Only re-peek if not already peeked.
+    if (peeked == null) {
+      depthBeforePeek = getCurrentDepthInternal();
+      peeked = nextInternal();
+    }
+    return peeked;
+  }
+
+  /**
+   * Returns the depth of the peeked element (the element returned with {@link #peek()}).<br>
+   * Returns {@value #PEEKED_DEPTH_NONE} if no element has been peeked yet or if the iterator has
+   * already been advanced with {@link #next()}.
+   *
+   * @return The depth of the peeked element
+   */
+  public int getPeekedDepth() {
+    return peeked != null ? getCurrentDepthInternal() : PEEKED_DEPTH_NONE;
+  }
+
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -1,5 +1,7 @@
 package com.mmm.his.cer.utility.farser.ast.node.type;
 
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
+
 /**
  * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
  * right child.

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -26,6 +26,12 @@ public abstract class NonTerminal<R> implements BooleanExpression<R> {
   }
 
   @Override
+  public String print() {
+    // A default printing behavior. Can be overridden by implementations if needed.
+    return getClass().getSimpleName().toUpperCase();
+  }
+
+  @Override
   public String toString() {
     return "NonTerminal{" + "left=" + left + ", right=" + right + '}';
   }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -6,24 +6,24 @@ import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
  * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
  * right child.
  *
- * @param <R> The type used in the terminal nodes.
+ * @param <C> The node context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public abstract class NonTerminal<R> implements BooleanExpression<R> {
+public abstract class NonTerminal<C> implements BooleanExpression<C> {
 
-  protected BooleanExpression<R> left;
-  protected BooleanExpression<R> right;
+  protected BooleanExpression<C> left;
+  protected BooleanExpression<C> right;
 
-  public void setLeft(BooleanExpression<R> left) {
+  public void setLeft(BooleanExpression<C> left) {
     this.left = left;
   }
 
-  public void setRight(BooleanExpression<R> right) {
+  public void setRight(BooleanExpression<C> right) {
     this.right = right;
   }
 
   @Override
-  public LtrExpressionIterator<R> iterator() {
+  public LtrExpressionIterator<C> iterator() {
     return new LtrExpressionIterator<>(left, right);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -4,20 +4,31 @@ package com.mmm.his.cer.utility.farser.ast.node.type;
  * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
  * right child.
  *
- * @param <C> The node context type used in the terminal nodes.
+ * @param <R> The type used in the terminal nodes.
  * @author Mike Funaro
  */
-public abstract class NonTerminal<C> implements BooleanExpression<C> {
+public abstract class NonTerminal<R> implements BooleanExpression<R> {
 
-  protected BooleanExpression<C> left;
-  protected BooleanExpression<C> right;
+  protected BooleanExpression<R> left;
+  protected BooleanExpression<R> right;
 
-  public void setLeft(BooleanExpression<C> left) {
+  public void setLeft(BooleanExpression<R> left) {
     this.left = left;
   }
 
-  public void setRight(BooleanExpression<C> right) {
+  public void setRight(BooleanExpression<R> right) {
     this.right = right;
+  }
+
+  @Override
+  public LtrExpressionIterator<R> iterator() {
+    return new LtrExpressionIterator<>(left, right);
+  }
+
+  @Override
+  public String print() {
+    // A default printing behavior. Can be overridden by implementations if needed.
+    return getClass().getSimpleName().toUpperCase();
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -26,12 +26,6 @@ public abstract class NonTerminal<R> implements BooleanExpression<R> {
   }
 
   @Override
-  public String print() {
-    // A default printing behavior. Can be overridden by implementations if needed.
-    return getClass().getSimpleName().toUpperCase();
-  }
-
-  @Override
   public String toString() {
     return "NonTerminal{" + "left=" + left + ", right=" + right + '}';
   }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
-import com.mmm.his.cer.utility.farser.ast.node.type.LtrExpressionIterator;
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -24,7 +24,7 @@ public class LtrExpressionIteratorTest {
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
         new StringOperandSupplier(), Collections.emptyMap());
 
-    System.out.println(lexerTokens);
+    // System.out.println(lexerTokens);
     AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
 
     LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
@@ -76,6 +76,7 @@ public class LtrExpressionIteratorTest {
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
         new StringOperandSupplier(), Collections.emptyMap());
 
+    // System.out.println(lexerTokens);
     AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
 
     LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -2,6 +2,7 @@ package com.mmm.his.cer.utility.farser.ast;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertThrows;
 
 import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
@@ -10,6 +11,7 @@ import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
@@ -34,35 +36,38 @@ public class LtrExpressionIteratorTest {
 
     // This printed order may look not right - see 'LtrExpressionIterator' javadoc about iteration
     // order and notation.
-    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.next().print(), is("OR"));
     assertThat(iter.getCurrentDepth(), is(1));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(2));
 
     assertThat(iter.next().print(), is("OR"));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
 
     assertThat(iter.next().print(), is("AND"));
-    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getCurrentDepth(), is(4));
 
     assertThat(iter.next().print(), is("A"));
-    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getCurrentDepth(), is(5));
 
     assertThat(iter.next().print(), is("B"));
-    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getCurrentDepth(), is(5));
 
     assertThat(iter.next().print(), is("C"));
-    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getCurrentDepth(), is(4));
 
     assertThat(iter.next().print(), is("D"));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
 
     assertThat(iter.next().print(), is("AND"));
-    assertThat(iter.getCurrentDepth(), is(1));
+    assertThat(iter.getCurrentDepth(), is(2));
 
     assertThat(iter.next().print(), is("E"));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
 
     assertThat(iter.next().print(), is("F"));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
 
     assertThrows(NoSuchElementException.class, iter::next);
     assertThat(iter.hasNext(), is(false));
@@ -84,85 +89,180 @@ public class LtrExpressionIteratorTest {
     assertThat(iter.hasNext(), is(true));
     assertThat(iter.getCurrentDepth(), is(0));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.peek().print(), is("AND"));
+    assertThat(iter.peek().print(), is("OR"));
     assertThat(iter.getCurrentDepth(), is(0));
     assertThat(iter.getPeekedDepth(), is(1));
+
     // Peek again, nothing should change
-    assertThat(iter.peek().print(), is("AND"));
+    assertThat(iter.peek().print(), is("OR"));
     assertThat(iter.getCurrentDepth(), is(0));
     assertThat(iter.getPeekedDepth(), is(1));
+    // --
 
     // This printed order may look not right - see 'LtrExpressionIterator' javadoc about iteration
     // order and notation.
-    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.next().print(), is("OR"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
     assertThat(iter.getCurrentDepth(), is(1));
-    assertThat(iter.peek().print(), is("OR"));
+    assertThat(iter.peek().print(), is("AND"));
     assertThat(iter.getCurrentDepth(), is(1));
     assertThat(iter.getPeekedDepth(), is(2));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.peek().print(), is("OR"));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getPeekedDepth(), is(3));
 
     assertThat(iter.next().print(), is("OR"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
     assertThat(iter.peek().print(), is("AND"));
-    assertThat(iter.getCurrentDepth(), is(2));
-    assertThat(iter.getPeekedDepth(), is(3));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getPeekedDepth(), is(4));
+
+    // -- Peek again, nothing should change
+    assertThat(iter.peek().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getPeekedDepth(), is(4));
+    // --
 
     assertThat(iter.next().print(), is("AND"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getCurrentDepth(), is(4));
     assertThat(iter.peek().print(), is("A"));
-    assertThat(iter.getCurrentDepth(), is(3));
-    assertThat(iter.getPeekedDepth(), is(4));
+    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getPeekedDepth(), is(5));
 
     assertThat(iter.next().print(), is("A"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getCurrentDepth(), is(5));
     assertThat(iter.peek().print(), is("B"));
-    assertThat(iter.getCurrentDepth(), is(4));
-    assertThat(iter.getPeekedDepth(), is(4));
+    assertThat(iter.getCurrentDepth(), is(5));
+    assertThat(iter.getPeekedDepth(), is(5));
 
     assertThat(iter.next().print(), is("B"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getCurrentDepth(), is(5));
     assertThat(iter.peek().print(), is("C"));
-    assertThat(iter.getCurrentDepth(), is(4));
-    assertThat(iter.getPeekedDepth(), is(3));
+    assertThat(iter.getCurrentDepth(), is(5));
+    assertThat(iter.getPeekedDepth(), is(4));
 
     assertThat(iter.next().print(), is("C"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getCurrentDepth(), is(4));
     assertThat(iter.peek().print(), is("D"));
-    assertThat(iter.getCurrentDepth(), is(3));
-    assertThat(iter.getPeekedDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getPeekedDepth(), is(3));
 
     assertThat(iter.next().print(), is("D"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
     assertThat(iter.peek().print(), is("AND"));
-    assertThat(iter.getCurrentDepth(), is(2));
-    assertThat(iter.getPeekedDepth(), is(1));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getPeekedDepth(), is(2));
 
     assertThat(iter.next().print(), is("AND"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(1));
+    assertThat(iter.getCurrentDepth(), is(2));
     assertThat(iter.peek().print(), is("E"));
-    assertThat(iter.getCurrentDepth(), is(1));
-    assertThat(iter.getPeekedDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getPeekedDepth(), is(3));
 
     assertThat(iter.next().print(), is("E"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
     assertThat(iter.peek().print(), is("F"));
-    assertThat(iter.getCurrentDepth(), is(2));
-    assertThat(iter.getPeekedDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getPeekedDepth(), is(3));
 
     assertThat(iter.next().print(), is("F"));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
-    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getCurrentDepth(), is(3));
     assertThrows(NoSuchElementException.class, iter::peek);
-    assertThat(iter.getCurrentDepth(), is(0));
+    assertThat(iter.getCurrentDepth(), is(3));
     assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+
+    assertThrows(NoSuchElementException.class, iter::next);
+    assertThat(iter.hasNext(), is(false));
+
+  }
+
+  @Test
+  public void testFullTreeIterationToString() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A & B | C");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    // System.out.println(lexerTokens);
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+
+    List<String> printed = new ArrayList<String>();
+    while (iter.hasNext()) {
+      String print = iter.next().print();
+      printed.add(print);
+    }
+
+    // left-to-right/"polish notation" order
+    // OR
+    // |-AND
+    // |..|-A
+    // |..\-B
+    // \-C
+    assertThat(printed, contains("OR", "AND", "A", "B", "C"));
+
+  }
+
+  @Test
+  public void testSingleAtomIterator() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    // System.out.println(lexerTokens);
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+
+    assertThat(iter.hasNext(), is(true));
+    assertThat(iter.getCurrentDepth(), is(0));
+
+    assertThat(iter.next().print(), is("A"));
+    assertThat(iter.getCurrentDepth(), is(1));
+
+    assertThrows(NoSuchElementException.class, iter::next);
+    assertThat(iter.hasNext(), is(false));
+
+  }
+
+  @Test
+  public void testSingleOperandIterator() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A & B");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    // System.out.println(lexerTokens);
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+
+    assertThat(iter.hasNext(), is(true));
+    assertThat(iter.getCurrentDepth(), is(0));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(1));
+
+    assertThat(iter.next().print(), is("A"));
+    assertThat(iter.getCurrentDepth(), is(2));
+
+    assertThat(iter.next().print(), is("B"));
+    assertThat(iter.getCurrentDepth(), is(2));
 
     assertThrows(NoSuchElementException.class, iter::next);
     assertThat(iter.hasNext(), is(false));

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -1,0 +1,171 @@
+package com.mmm.his.cer.utility.farser.ast;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.node.type.LtrExpressionIterator;
+import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
+import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
+import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
+import java.util.Collections;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.junit.Test;
+
+public class LtrExpressionIteratorTest {
+
+  @Test
+  public void testFullTreeIteration() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A & B | C) & D | (E & F)");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    System.out.println(lexerTokens);
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+
+    assertThat(iter.hasNext(), is(true));
+    assertThat(iter.getCurrentDepth(), is(0));
+
+    // This printed order may look not right - see 'LtrExpressionIterator' javadoc about iteration
+    // order and notation.
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(1));
+
+    assertThat(iter.next().print(), is("OR"));
+    assertThat(iter.getCurrentDepth(), is(2));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(3));
+
+    assertThat(iter.next().print(), is("A"));
+    assertThat(iter.getCurrentDepth(), is(4));
+
+    assertThat(iter.next().print(), is("B"));
+    assertThat(iter.getCurrentDepth(), is(4));
+
+    assertThat(iter.next().print(), is("C"));
+    assertThat(iter.getCurrentDepth(), is(3));
+
+    assertThat(iter.next().print(), is("D"));
+    assertThat(iter.getCurrentDepth(), is(2));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(1));
+
+    assertThat(iter.next().print(), is("E"));
+    assertThat(iter.getCurrentDepth(), is(2));
+
+    assertThat(iter.next().print(), is("F"));
+    assertThat(iter.getCurrentDepth(), is(2));
+
+    assertThrows(NoSuchElementException.class, iter::next);
+    assertThat(iter.hasNext(), is(false));
+
+  }
+
+  @Test
+  public void testFullTreeIterationWithPeek() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A & B | C) & D | (E & F)");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+
+    assertThat(iter.hasNext(), is(true));
+    assertThat(iter.getCurrentDepth(), is(0));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.peek().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(0));
+    assertThat(iter.getPeekedDepth(), is(1));
+    // Peek again, nothing should change
+    assertThat(iter.peek().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(0));
+    assertThat(iter.getPeekedDepth(), is(1));
+
+    // This printed order may look not right - see 'LtrExpressionIterator' javadoc about iteration
+    // order and notation.
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(1));
+    assertThat(iter.peek().print(), is("OR"));
+    assertThat(iter.getCurrentDepth(), is(1));
+    assertThat(iter.getPeekedDepth(), is(2));
+
+    assertThat(iter.next().print(), is("OR"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.peek().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getPeekedDepth(), is(3));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.peek().print(), is("A"));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getPeekedDepth(), is(4));
+
+    assertThat(iter.next().print(), is("A"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.peek().print(), is("B"));
+    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getPeekedDepth(), is(4));
+
+    assertThat(iter.next().print(), is("B"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.peek().print(), is("C"));
+    assertThat(iter.getCurrentDepth(), is(4));
+    assertThat(iter.getPeekedDepth(), is(3));
+
+    assertThat(iter.next().print(), is("C"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.peek().print(), is("D"));
+    assertThat(iter.getCurrentDepth(), is(3));
+    assertThat(iter.getPeekedDepth(), is(2));
+
+    assertThat(iter.next().print(), is("D"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.peek().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getPeekedDepth(), is(1));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(1));
+    assertThat(iter.peek().print(), is("E"));
+    assertThat(iter.getCurrentDepth(), is(1));
+    assertThat(iter.getPeekedDepth(), is(2));
+
+    assertThat(iter.next().print(), is("E"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.peek().print(), is("F"));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThat(iter.getPeekedDepth(), is(2));
+
+    assertThat(iter.next().print(), is("F"));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+    assertThat(iter.getCurrentDepth(), is(2));
+    assertThrows(NoSuchElementException.class, iter::peek);
+    assertThat(iter.getCurrentDepth(), is(0));
+    assertThat(iter.getPeekedDepth(), is(LtrExpressionIterator.PEEKED_DEPTH_NONE));
+
+    assertThrows(NoSuchElementException.class, iter::next);
+    assertThat(iter.hasNext(), is(false));
+
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -7,12 +7,14 @@ import static org.junit.Assert.assertThrows;
 
 import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import org.junit.Test;
@@ -199,7 +201,7 @@ public class LtrExpressionIteratorTest {
     // System.out.println(lexerTokens);
     AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
 
-    LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+    Iterator<BooleanExpression<MaskedContext<String>>> iter = ast.iterator();
 
     List<String> printed = new ArrayList<String>();
     while (iter.hasNext()) {

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/ContainsNodeForContext.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/ContainsNodeForContext.java
@@ -19,4 +19,9 @@ public class ContainsNodeForContext<T> implements BooleanExpression<MaskedContex
     }
     return false;
   }
+
+  @Override
+  public String print() {
+    return String.valueOf(value);
+  }
 }


### PR DESCRIPTION
The top level `AbstractSyntaxTree` class and all AST nodes now implement `Iterator`. The iterator behavior is implemented as `LtrExpressionIterator` to iterate in the LTR/left-to-right order like the formula evaluation is implemented.

See the `readme.md` iterator documentation for details.

As a bonus, all nodes got a `print()` method which returns a string representation of the node. This provides a very simple way to produce some textual representation of the formula/tree.