### PR TITLE
AST printing in iteration order

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -281,6 +281,40 @@ while (iter.hasNext()) {
 ```
 
 
+#### Abstract Syntax Tree Printing
+
+An instance of `AbstractSyntaxTree` can be printed in textual form using the 
+`AbstractSyntaxTreePrinter`. The printer follows the iteration documented 
+above, meaning that the printed output is in LTR/"Polish/prefix notation" form.
+
+```java
+String formula = "(A & B | C) & D";
+...
+AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+String printed = AbstractSyntaxTreePrinter.printTree(ast);
+System.out.println(printed);
+```
+
+results in
+
+```text
+AND
+  OR
+    AND
+      A
+      B
+    C
+  D
+```
+
+The output value of each node can be controlled with an optional printing 
+function provided to the `AbstractSyntaxTreePrinter.printTree` call. 
+The function can then be used to print additional (context) information, 
+evaluate each node and show the result, add structure symbols to the
+output (e.g. JSON symbols) and so on.
+
+
 #### Abstract Syntax Tree Examples
 
 The following diagrams are a visual representation of the AST after it was parsed by the descent parser.

--- a/readme.md
+++ b/readme.md
@@ -313,6 +313,9 @@ function provided to the `AbstractSyntaxTreePrinter.printTree` call.
 The function can then be used to print additional (context) information, 
 evaluate each node and show the result, add structure symbols to the
 output (e.g. JSON symbols) and so on.
+The printer context `AstPrinterContext` contains information like 
+peek (looking at the next element and depth), the indentation prefix 
+string to use and the "depth direction" of the current and next node.
 
 
 #### Abstract Syntax Tree Examples

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTreePrinter.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTreePrinter.java
@@ -1,0 +1,300 @@
+package com.mmm.his.cer.utility.farser.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+/**
+ * A printer to output a {@link DrgSyntaxTree} in visual representation.
+ *
+ * @author Thomas Naeff
+ *
+ */
+public final class AbstractSyntaxTreePrinter {
+
+  public static final String DEFAULT_INDENTATION = "  ";
+
+  private AbstractSyntaxTreePrinter() {
+    // Private. Only static methods.
+  }
+
+  /**
+   * Prints a simple tree representation.<br>
+   * Uses {@link #printNodeSimple(BooleanExpression)}.
+   *
+   * @param ast The AST
+   * @return The tree representation as string
+   */
+  public static String printTree(AbstractSyntaxTree<?> ast) {
+    return printTree(ast, DEFAULT_INDENTATION, AbstractSyntaxTreePrinter::printNodeSimple);
+  }
+
+  /**
+   *
+   * Prints a tree representation based on the provided node printing function.
+   *
+   * @param ast       The AST to print
+   * @param printNode The function which determines how to print a node. The
+   *                  {@link BooleanExpression} function input may be <code>null</code> when the
+   *                  printing is past the last node (to possibly finalize/close data structures).
+   *                  See {@link #printNodeSimple(BooleanExpression, AstPrinterContext)} for a
+   *                  simple starting point.
+   * @return
+   */
+  public static <T> String printTree(AbstractSyntaxTree<T> ast,
+      Function<BooleanExpression<T>, String> printNode) {
+    return printTree(ast, DEFAULT_INDENTATION, (node, next) -> printNode.apply(node));
+  }
+
+  /**
+   * Prints a simple tree representation.
+   *
+   * @param ast       The AST
+   * @param printNode The function which determines how to print a node. The
+   *                  {@link BooleanExpression} function input may be <code>null</code> when the
+   *                  printing is past the last node (to possibly finalize/close data structures).
+   *                  See {@link #printNodeSimple(BooleanExpression, AstPrinterContext)} for a
+   *                  simple starting point.
+   * @return The tree representation as string
+   */
+  public static <T> String printTree(AbstractSyntaxTree<T> ast,
+      BiFunction<BooleanExpression<T>, AstPrinterContext<T>, String> printNode) {
+    return printTree(ast, DEFAULT_INDENTATION, printNode);
+  }
+
+  /**
+   * Prints a simple tree representation.
+   *
+   * @param ast       The AST
+   * @param printNode The function which determines how to print a node. The
+   *                  {@link BooleanExpression} function input may be <code>null</code> when the
+   *                  printing is past the last node (to possibly finalize/close data structures).
+   *                  See {@link #printNodeSimple(BooleanExpression, AstPrinterContext)} for a
+   *                  simple starting point.
+   * @return The tree representation as string
+   */
+  public static <T> String printTree(AbstractSyntaxTree<T> ast, String indentation,
+      BiFunction<BooleanExpression<T>, AstPrinterContext<T>, String> printNode) {
+    StringBuilder sb = new StringBuilder();
+    int previousDepth = 0;
+    int currentDepth = 0;
+
+    List<String> prefixes = new ArrayList<>();
+    LtrExpressionIterator<T> iter = ast.iterator();
+
+    while (iter.hasNext()) {
+      // Need to get next first, so that depth of new/current node is available.
+      BooleanExpression<T> node = iter.next();
+      previousDepth = currentDepth;
+      currentDepth = iter.getCurrentDepth();
+
+      String prefix = prefix(prefixes, currentDepth, indentation);
+      AstPrinterContext<T> context = createPrinterContext(iter, prefix, previousDepth);
+      appendPrinted(sb, printNode, node, context);
+    }
+
+    // Call the printing again for each depth, from the current node all the way back up to the
+    // root depth. This allows the printer to possibly close any nesting-dependent structures.
+    int nextDepth = iter.getPeekedDepth();
+    for (; currentDepth >= 1; currentDepth--) {
+      String prefix = prefix(prefixes, currentDepth, indentation);
+      AstPrinterContext<T> context = new AstPrinterContext<>(prefix, currentDepth,
+          AstPrintDirection.UP, null, nextDepth, AstPrintDirection.UP);
+      appendPrinted(sb, printNode, null, context);
+    }
+
+    return sb.toString();
+  }
+
+  /**
+   * Handles the printer function execution and adding it to the buffer.
+   *
+   * @param sb        The buffer to add to
+   * @param printNode The printer function
+   * @param node      The node to print. May be <code>null</code>.
+   * @param context   The printer context
+   */
+  private static <T> void appendPrinted(StringBuilder sb,
+      BiFunction<BooleanExpression<T>, AstPrinterContext<T>, String> printNode,
+      BooleanExpression<T> node, AstPrinterContext<T> context) {
+    String printed = printNode.apply(node, context);
+    // Do not add if printer function returned NULL. Documented behavior on this printer class
+    // constructors.
+    if (printed != null ) {
+      sb.append(printed);
+    }
+  }
+
+  /**
+   * Gathers information to create the {@link AstPrinterContext}.
+   *
+   * @param iter          The current iterator
+   * @param prefix        The current prefix
+   * @param previousDepth The depth of the previous node
+   * @return The context object
+   */
+  private static <T> AstPrinterContext<T> createPrinterContext(LtrExpressionIterator<T> iter,
+      String prefix, int previousDepth) {
+    BooleanExpression<T> peeked = null;
+    peeked = iter.hasNext() ? iter.peek() : null;
+
+    int currentDepth = iter.getCurrentDepth();
+    int peekedDepth = iter.getPeekedDepth();
+    AstPrintDirection direction = AstPrintDirection.fromDepthDelta(currentDepth - previousDepth);
+    AstPrintDirection peekedDirection =
+        AstPrintDirection.fromDepthDelta(peekedDepth - currentDepth);
+
+    return new AstPrinterContext<>(prefix, currentDepth, direction, peeked, peekedDepth,
+        peekedDirection);
+  }
+
+  /**
+   * This method maintains the list of prefixes for each depth.
+   *
+   * @param prefixes    The prefixes cache (with the depth as list index). This collections gets
+   *                    updated internally.
+   * @param depth       The depth of the node
+   * @param indentation The indentation to add for each new depth
+   * @return The prefix for the <code>currentDepth</code>
+   */
+  private static String prefix(List<String> prefixes, int depth, String indentation) {
+    if (prefixes.size() >= depth) {
+      // If a prefix already exists for the current depth, then return it.
+      return prefixes.get(depth - 1);
+    } else if (depth == 1) {
+      // No prefixes cached yet.
+      // Start out with an empty prefix.
+      prefixes.add("");
+      return "";
+    } else {
+      // Otherwise take the previous prefix, append one additional indentation,
+      // then store and return it.
+      int previousDepth = depth - 1;
+      String previous = prefixes.get(previousDepth - 1);
+      String newPrefix = previous + indentation;
+      prefixes.add(newPrefix);
+      return newPrefix;
+    }
+
+  }
+
+  /**
+   * The simplest version of printing a node.<br>
+   * This implementation indentates the nodes and ignores any "closing" structured indentation at
+   * the end.<br>
+   * This is a method that could be provided to {@link #printTree(DrgSyntaxTree, Function)}.
+   *
+   * @param node The node to print
+   * @return The printed representation
+   */
+  public static String printNodeSimple(BooleanExpression<?> node, AstPrinterContext<?> context) {
+    // Ignore any "closing" structure at the end of the tree.
+    if (node == null) {
+      return null;
+    }
+
+    StringBuilder sb = new StringBuilder();
+    sb.append(context.prefix);
+    sb.append(node.print());
+    sb.append(System.lineSeparator());
+    return sb.toString();
+  }
+
+
+  /***********************************************************************************************************************
+   *
+   *
+   * @author Thomas Naeff
+   *
+   * @param <T>
+   */
+  public static class AstPrinterContext<T> {
+
+    /**
+     * The tree depth of the current node. Either 0 (zero) or a positive value.
+     */
+    public final int depth;
+
+    /**
+     * The tree depth of the {@link #next} node. Either 0 (zero) or a positive value if
+     * {@link #next} is not <code>null</code>, or {@value LtrExpressionIterator#PEEKED_DEPTH_NONE}
+     * when {@link #next} is <code>null</code>.
+     */
+    public final int nextDepth;
+
+    /**
+     * The prefix for indentation. Never <code>null</code>.
+     */
+    public final String prefix;
+
+    /**
+     * The direction of the nesting - in relation to the previous node. Never <code>null</code>.
+     */
+    public final AstPrintDirection direction;
+
+    /**
+     * The next direction of the nesting - in relation to the current node. May be <code>null</code>
+     * when the last node is reached.
+     */
+    public final AstPrintDirection nextDirection;
+
+    /**
+     * The next node (peek). May be <code>null</code> when the iteration/printing is at or past the
+     * last node.
+     */
+    public final BooleanExpression<T> next;
+
+    private AstPrinterContext(String prefix, int depth, AstPrintDirection direction,
+        BooleanExpression<T> next, int nextDepth, AstPrintDirection nextDirection) {
+      this.depth = depth;
+      this.nextDepth = nextDepth;
+      this.prefix = prefix;
+      this.direction = direction;
+      this.nextDirection = nextDirection;
+      this.next = next;
+    }
+
+  }
+
+  /**
+   * An enumeration with a few flags that inform about the printing direction of one node in
+   * relation to its previous node.
+   *
+   * @author Thomas Naeff
+   *
+   */
+  public enum AstPrintDirection {
+    /**
+     * Travelling on same level in the tree (depth is the same as the previous node).
+     */
+    SAME,
+    /**
+     * Travelling up the tree (depth got reduced compared to the previous node).
+     */
+    UP,
+    /**
+     * Travelling down the tree (depth got increased compared to the previous node).
+     */
+    DOWN;
+
+    /**
+     * Returns the direction identifier based on the node depth delta (current/next node depth minus
+     * previous node depth).
+     *
+     * @param depthDelta The depth delta
+     * @return The direction
+     */
+    public static AstPrintDirection fromDepthDelta(int depthDelta) {
+      if (depthDelta > 0) {
+        return AstPrintDirection.DOWN;
+      } else if (depthDelta < 0) {
+        return AstPrintDirection.UP;
+      }
+      return AstPrintDirection.SAME;
+    }
+  }
+
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTreePrinter.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTreePrinter.java
@@ -8,7 +8,8 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 
 /**
- * A printer to output a {@link DrgSyntaxTree} in visual representation.
+ * A printer to output an {@link AbstractSyntaxTree} in visual representation, for example to
+ * convert a formula to a different format or simply for debugging or display purposes.
  *
  * @author Thomas Naeff
  *

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
@@ -69,7 +69,8 @@ public class PrintingJsonTest {
 
 
   /********************************************************************************************************
-   *
+   * A very rudimentary implementation to print the formula as JSON. This was just implemented to
+   * get it to work and see if it can be possible. A lot in this code is not very nice :)
    *
    * @author Thomas Naeff
    *

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
@@ -1,0 +1,168 @@
+package com.mmm.his.cer.utility.farser.ast;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrintDirection;
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
+import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
+import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
+import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class PrintingJsonTest {
+
+  @Test
+  public void testPrintTreeAsJson() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A & B | C) & D | (E & F & G)");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    NodePrinterJson nodePrinter = new NodePrinterJson();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, nodePrinter::printNode);
+    printed = "{" + System.lineSeparator() + printed + System.lineSeparator() + "}";
+
+    String[] lines = printed.split(System.lineSeparator());
+
+    String[] expected = new String[] {
+        "{",
+        "\"OR\": {",
+        "  \"AND\": {",
+        "    \"OR\": {",
+        "      \"AND\": [\"A\", \"B\"      ], ",
+        "      \"1\": \"C\"",
+        "    }, ",
+        "    \"2\": \"D\"",
+        "  }, ",
+        "  \"AND\": {",
+        "    \"AND\": [\"E\", \"F\"    ], ",
+        "    \"3\": \"G\"",
+        "    }",
+        "  }",
+        "",
+        "}"
+    };
+    System.out.println("=== expected ===");
+    System.out.println(Arrays.stream(expected).collect(Collectors.joining(System.lineSeparator())));
+    System.out.println("=== actual ===");
+    System.out.println(printed);
+    assertThat(lines, is(expected));
+
+  }
+
+
+  /********************************************************************************************************
+   *
+   *
+   * @author Thomas Naeff
+   *
+   * @param <T>
+   */
+  private static class NodePrinterJson {
+
+    private LinkedList<String> closingBrackets = new LinkedList<>();
+    private int generatedKey = 1;
+
+    private NodePrinterJson() {}
+
+    public String printNode(BooleanExpression<?> node, AstPrinterContext<?> printerContext) {
+      StringBuilder sb = new StringBuilder();
+
+      if ((printerContext.direction == AstPrintDirection.UP) && !closingBrackets.isEmpty()) {
+        // sb.append(String.format("%02d", printerContext.depth));
+        sb.append(printerContext.prefix);
+        String bracket = closingBrackets.removeLast();
+        sb.append(bracket);
+        // Do not add a comma when printing is past the last node
+        if (node != null) {
+          sb.append(", ");
+        }
+        sb.append(System.lineSeparator());
+      }
+
+      if (node != null) {
+        // sb.append(String.format("%02d", printerContext.depth));
+        if ((node instanceof NonTerminal) && (printerContext.next instanceof NonTerminal)) {
+          sb.append(printerContext.prefix);
+          // sb.append(node.getClass().getSimpleName());
+          sb.append("\"");
+          sb.append(node.print());
+          sb.append("\": {");
+          closingBrackets.add("}");
+          sb.append(System.lineSeparator());
+        } else if ((node instanceof NonTerminal)
+            && (printerContext.next instanceof BooleanExpression)) {
+          sb.append(printerContext.prefix);
+          // sb.append(node.getClass().getSimpleName());
+          sb.append("\"");
+          sb.append(node.print());
+          sb.append("\": [");
+          closingBrackets.add("]");
+        } else if ((node instanceof BooleanExpression)
+            && (printerContext.next instanceof BooleanExpression)) {
+          if (printerContext.direction == AstPrintDirection.UP) {
+            sb.append(printerContext.prefix);
+          }
+          // sb.append(node.getClass().getSimpleName());
+
+          // If the element is in an object, add some generated key to be valid JSON
+          if (closingBrackets.getLast().contains("}")) {
+            sb.append("\"");
+            sb.append(generatedKey);
+            sb.append("\": ");
+            generatedKey += 1;
+          }
+
+          sb.append("\"");
+          sb.append(node.print());
+          sb.append("\"");
+          if ((printerContext.direction != AstPrintDirection.UP)
+              && (printerContext.nextDirection != AstPrintDirection.UP)) {
+            sb.append(", ");
+          }
+          if (printerContext.direction == AstPrintDirection.UP) {
+            sb.append(System.lineSeparator());
+          }
+        } else {
+          sb.append(printerContext.prefix);
+          // sb.append(node.getClass().getSimpleName());
+
+          // If the element is in an object, add some generated key to be valid JSON
+          if (closingBrackets.getLast().contains("}")) {
+            sb.append("\"");
+            sb.append(generatedKey);
+            sb.append("\": ");
+            generatedKey += 1;
+          }
+
+          sb.append("\"");
+          sb.append(node.print());
+          sb.append("\"");
+          sb.append(System.lineSeparator());
+        }
+      }
+
+      return sb.toString();
+    }
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
@@ -12,11 +12,9 @@ import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.Test;
 
 /**
@@ -61,10 +59,10 @@ public class PrintingJsonTest {
         "",
         "}"
     };
-    System.out.println("=== expected ===");
-    System.out.println(Arrays.stream(expected).collect(Collectors.joining(System.lineSeparator())));
-    System.out.println("=== actual ===");
-    System.out.println(printed);
+    // System.out.println("=== expected ===");
+    // System.out.println(Arrays.stream(expected).collect(Collectors.joining(System.lineSeparator())));
+    // System.out.println("=== actual ===");
+    // System.out.println(printed);
     assertThat(lines, is(expected));
 
   }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
@@ -1,0 +1,237 @@
+package com.mmm.his.cer.utility.farser.ast;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
+import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
+import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.setup.TestContext;
+import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
+import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Test;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class PrintingTest {
+
+  @Test
+  public void testPrintTree() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A & B | C) & D | (E & F)");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNode);
+    String[] lines = printed.split(System.lineSeparator());
+
+    System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR",
+        "02  AND",
+        "03    OR",
+        "04      AND",
+        "05        A",
+        "05        B",
+        "04      C",
+        "03    D",
+        "02  AND",
+        "03    E",
+        "03    F"
+    }));
+
+  }
+
+  @Test
+  public void testSimplestFormula1() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | B & C");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNode);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR",
+        "02  A",
+        "02  AND",
+        "03    B",
+        "03    C"
+    }));
+
+  }
+
+  @Test
+  public void testSimplestFormula2() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A & B | C");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNode);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR",
+        "02  AND",
+        "03    A",
+        "03    B",
+        "02  C"
+    }));
+
+  }
+
+  @Test
+  public void testPrintTreeWithPeek() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A & B | C) & D | (E & F)");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNodeWithPeek);
+    String[] lines = printed.split(System.lineSeparator());
+
+    //    System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR next=AND",
+        "02  AND next=OR",
+        "03    OR next=AND",
+        "04      AND next=A",
+        "05        A next=B",
+        "05        B next=C",
+        "04      C next=D",
+        "03    D next=AND",
+        "02  AND next=E",
+        "03    E next=F",
+        "03    F next=NONE",
+        "03    ",
+        "02  ",
+        "01"
+    }));
+
+  }
+
+  @Test
+  public void testPrintTreeEvaluated() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A & B | C) & D | (E & F)");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+    List<String> mask = Arrays.asList("A", "C");
+
+    NodePrinterWithContextData<MaskedContext<String>> nodePrinter =
+        new NodePrinterWithContextData<>(new TestContext<>(mask));
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, nodePrinter::printNode);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "OR = false",
+        "  AND = false",
+        "    OR = true",
+        "      AND = false",
+        "        A = true",
+        "        B = false",
+        "      C = true",
+        "    D = false",
+        "  AND = false",
+        "    E = false",
+        "    F = false"
+    }));
+
+  }
+
+
+  /********************************************************************************************************
+   *
+   *
+   * @author Thomas Naeff
+   *
+   * @param <T>
+   */
+  private static class NodePrinterWithContextData<T> {
+
+    private final T evaluationContext;
+
+    private NodePrinterWithContextData(T printerContext) {
+      this.evaluationContext = printerContext;
+    }
+
+    /**
+     * Prints the output of a single node.
+     *
+     * @param node           The node to print
+     * @param printerContext The printerContext for node evaluation. May be <code>null</code> to
+     *                       skip evaluation
+     * @return The node output
+     */
+    public String printNode(BooleanExpression<T> node, AstPrinterContext<?> printerContext) {
+      StringBuilder sb = new StringBuilder();
+      if (node != null) {
+        sb.append(printerContext.prefix);
+        sb.append(node.print());
+        if (evaluationContext != null) {
+          boolean result = node.evaluate(evaluationContext);
+          sb.append(" = " + result);
+        }
+        sb.append(System.lineSeparator());
+      }
+      return sb.toString();
+    }
+
+  }
+
+
+  public static String printNode(BooleanExpression<?> node, AstPrinterContext<?> printerContext) {
+    if (node == null) {
+      return null;
+    }
+
+    StringBuilder sb = new StringBuilder();
+    // Print node depth to verify it
+    sb.append(String.format("%02d", printerContext.depth));
+    sb.append(printerContext.prefix);
+    sb.append(node.print());
+    sb.append(System.lineSeparator());
+    return sb.toString();
+  }
+
+  public static String printNodeWithPeek(BooleanExpression<?> node,
+      AstPrinterContext<?> printerContext) {
+    StringBuilder sb = new StringBuilder();
+    // Print depth to ensure it does not get affected by the peek
+    sb.append(String.format("%02d", printerContext.depth));
+    sb.append(printerContext.prefix);
+    if (node != null) {
+      sb.append(node.print());
+      sb.append(" next=");
+      sb.append(printerContext.next == null ? "NONE" : printerContext.next.print());
+    }
+    sb.append(System.lineSeparator());
+    return sb.toString();
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
@@ -124,7 +124,7 @@ public class PrintingTest {
         "02  AND next=E",
         "03    E next=F",
         "03    F next=NONE",
-        "03    ",
+        "03    ", // Including the "closing" structure of each node
         "02  ",
         "01"
     }));

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
@@ -36,7 +36,7 @@ public class PrintingTest {
     String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNode);
     String[] lines = printed.split(System.lineSeparator());
 
-    System.out.println(printed);
+    // System.out.println(printed);
     assertThat(lines, is(new String[] {
         "01OR",
         "02  AND",
@@ -111,7 +111,7 @@ public class PrintingTest {
     String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNodeWithPeek);
     String[] lines = printed.split(System.lineSeparator());
 
-    //    System.out.println(printed);
+    //System.out.println(printed);
     assertThat(lines, is(new String[] {
         "01OR next=AND",
         "02  AND next=OR",


### PR DESCRIPTION
This PR adds a new and completely independent `AbstractSyntaxTreePrinter` (meaning, no existing code has been touched for this addition).

The printing utilizes the AST iteration with `LtrExpressionIterator`.

See "Abstract Syntax Tree Printing" in the `readme.md` for details and the unit tests for some examples.