### PR TITLE
Any operator with precedence - potentially breaking changes

### DIFF
--- a/implementYourOwnAst.md
+++ b/implementYourOwnAst.md
@@ -1,0 +1,241 @@
+# Implement your own Abstract Syntax Tree
+
+This documentation shows the implementation needed to produce an AST with your custom tokens 
+(operands, operators, ...). The basis for this is a list of lexer tokens 
+(minimally an implementation of `TokenType`  and `LexerToken` from 
+["Implement your own Lexer"](implementYourOwnLexer.md)). A list of such tokens can then 
+be used to produce an AST with the additions documented here.
+
+
+## 1. Implement an AstTokenType
+
+The `AstTokenType` interface is an extension to the lexer `TokenType`. These two
+interfaces are separated to clearly separate the AST vs. the lexer library implementation.
+
+With this truncated example from the [lexer documentation](implementYourOwnLexer.md), 
+we can now also add the `AstTokenType` interface and configure it with the additional 
+data needed for building the AST:
+
+ - Flag specific tokens with common types available in `AstCommonTokenType`
+ - Define the operator precedence
+
+
+```java
+public enum MyOwnTokenType implements TokenType<MyOwnTokenType>, AstTokenType<MyOwnTokenType> {
+
+  ATOM(null, CommonTokenType.ATOM),
+  SPACE(" ", CommonTokenType.SPACE),
+  LPAREN("(", AstCommonTokenType.LPAREN),
+  RPAREN(")", AstCommonTokenType.RPAREN),
+
+  AND("&&", 2), // Lower value = higher precedence (stronger bond).
+  OR("||", 3),  // See javadoc on 'getOperatorPrecedence()'.
+  GT(">", 1),   // Multiple operators may have the same precedence.
+  LT("<", 1),
+
+  ...
+  
+  private final int operatorPrecedence;
+  
+  MyOwnTokenType(String value, CommonTokenFlag commonType) {
+    this.value = value;
+    this.commonType = commonType;
+    this.operatorPrecedence = AstTokenType.NOT_AN_OPERATOR;
+  }
+
+  MyOwnTokenType(String value, int operatorPrecedence) {
+    this.value = value;
+    this.commonType = null;
+    this.operatorPrecedence = operatorPrecedence;
+  }
+  
+  ...
+
+  @Override
+  public int getOperatorPrecedence() {
+    return operatorPrecedence;
+  }
+  
+}
+```
+
+
+## 2. Implement Terminal Nodes (variables/values)
+
+Terminal nodes are the ones which do not have to perform an operation based on an operator. 
+A terminal node can be a scalar value, some string, a variable or some other keyword or 
+special function which needs a dedicated programmatic implementation.
+
+The formula `A > 5 & MY_FUNC`  for example will produce terminal nodes for `A`, `5` 
+and `MY_FUNC`.
+
+This example formula means that we need 3 types of terminal nodes:
+
+ - One that substitutes the variable `A` with a number to be able to use it in the greater-than evaluation
+ - One that simply returns the `5`
+ - One that implements some special logic for `MY_FUNC` and returns a boolean result
+
+The implementations are done by implementing `[Boolean]Expression`. The following example is the 
+implementation which returns an integer for `5`.
+
+```java
+public class MyTerminalNode implements Expression<MyAstContext, Integer> {
+
+  private final MyToken token;
+
+  public MyTerminalNode(MyToken token) {
+    this.token = token;
+  }
+
+  @Override
+  public Integer evaluate(MyAstContext context) {
+    return Integer.valueOf(token.getValue());
+  }
+
+  @Override
+  public String print() {
+    return token.value;
+  }
+
+  @Override
+  public String toString() {
+    return token.value;
+  }
+
+}
+```
+
+
+
+## 3. Implement Non-Terminal Nodes (Operators)
+
+All the operators (the `[Ast]TokenType` enum elements which have an operator precedence set) 
+will need an implementation to program the logic on how to evaluate them. For example the 
+operator `>` (greater than) will need an implementation to evaluate *5 > 2*.
+
+The implementations are done by implementing `[Boolean]NonTerminal`. Each node has a 
+"left" and a "right" value (which may be the result of a nested child node evaluation) which 
+it then has to evaluate based on its operator.
+
+```java
+public class MyGreaterThanOperator<C> extends NonTerminal<C, Integer> {
+
+  @Override
+  public Boolean evaluate(C context) {
+    return left.evaluate(context) > right.evaluate(context);
+  }
+
+  @Override
+  public String print() {
+    return "GREATER-THAN";
+  }
+
+  @Override
+  public String toString() {
+    return "GreaterThan{" + "left=" + left + ", right=" + right + '}';
+  }
+}
+```
+
+## 4. Create a Context Class
+
+A context object can be passed in to the evaluation. This context object is then passed 
+to all the node evaluation (`Boolean evaluate(C context)`) calls. The context 
+object can be used to record evaluation steps, provide data needed for the evaluation etc.
+
+```java
+public class MyAstContext {
+
+  List<String> listOfValuesWhichAreTrue = ...;
+  List<String> listOfNodesWhichGotVisitedDuringEvaluation = ...;
+  
+  ...
+
+}
+```
+
+If no evaluation context is needed, then an empty class implementation can be provided.
+
+
+
+## 5. Implement a NodeSupplier
+
+Now that each operator (non-terminal node) has an implementation and we have a value 
+(terminal node) implementation, we need to tie the token (enum) type together with 
+its implementation. An implementation of a `NodeSupplier` can contain 
+any needed logic to create those instances.
+
+```java
+public class MyAstNodeSupplier implements NodeSupplier<MyOwnToken, MyAstContext> {
+
+  @Override
+  public Expression<MyAstContext, ?> createNode(MyOwnToken inToken) {
+      // The node can be created based on some keywords
+      if ("MY_FUNCTION".equals(token.getValue())) {
+        return new MySpecialFunctionNode(inToken);
+      } else {
+        return new MyTerminalNode<MyAstContext>(inToken);
+      }
+  }
+
+
+  @Override
+  public NonTerminal<MyAstContext, ?> createNonTerminalNode(MyOwnToken token) {
+
+    switch (token.type) {
+      case GT:
+        return new MyGreaterThanOperator<>();
+      case LT:
+        return new MyLessThanOperator<>();
+        
+      // A few node types which are already implemented in this libary.
+      // Use them or create your own.
+      case AND:
+        return new And<>();
+      case OR:
+        return new Or<>();
+      case NOT:
+        return new Not<>();
+        
+      default:
+        throw new FarserException("Operator type " + token + " not implemented");
+    }
+
+  }
+
+}
+```
+
+
+
+## 6. Use it
+
+Build the AST:
+
+```java
+List<MyOwnToken> tokens = ...;
+
+NodeSupplier<MyToken, MyAstContext> nodeSupplier = new MyAstNodeSupplier();
+
+AstDescentParser<MyToken, MyTokenType, MyAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), nodeSupplier);
+
+AbstractSyntaxTree<MyAstContext> ast = parser.buildTree();
+```
+
+Now evaluate it, print it, ...
+
+```java
+MyAstContext context = ...;
+// Evaluate the whole tree with...
+ExpressionResult<MyAstContext> result = ast.evaluateExpression(context);
+// ...or
+Boolean result = ast.evaluate(context);
+
+// Print the AST
+String printed = AbstractSyntaxTreePrinter.printTree(ast);
+System.out.println(printed);
+```
+
+
+

--- a/implementYourOwnLexer.md
+++ b/implementYourOwnLexer.md
@@ -22,16 +22,16 @@ public enum MyOwnTokenType implements TokenType<MyOwnTokenType> {
 
   ATOM(null, CommonTokenType.ATOM),
   SPACE(" ", CommonTokenType.SPACE),
-  LPAREN("(", CommonTokenType.LPAREN),
-  RPAREN(")", CommonTokenType.RPAREN),
+  LPAREN("("),
+  RPAREN(")"),
 
   AND("&&"),
   OR("||");
 
   private final String value;
-  private final CommonTokenType commonType;
+  private final CommonTokenFlag commonType;
 
-  MyOwnTokenType(String value, CommonTokenType commonType) {
+  MyOwnTokenType(String value, CommonTokenFlag commonType) {
     this.value = value;
     this.commonType = commonType;
   }
@@ -46,7 +46,7 @@ public enum MyOwnTokenType implements TokenType<MyOwnTokenType> {
   }
 
   @Override
-  public Optional<CommonTokenType> getCommonTokenType() {
+  public Optional<CommonTokenFlag> getCommonTokenType() {
     return Optional.ofNullable(commonType);
   }
 }
@@ -74,7 +74,7 @@ This class represents an instance (a container) of each token - with *type* and 
 A list of `LexerToken` is produced by the lexer.
 
 The *value* in this token class is generally the same as the value of the `TokenType` enum. Only 
-for `ATOM` tokens the value will be something different - the *value* will be whatever the value 
+for `ATOM` tokens the value will be something different - the ATOM *value* will be whatever the value 
 from the formula is.
 
 Depending on the `LexerTokenFactory` implementation, this token class can also contain other 

--- a/readme.md
+++ b/readme.md
@@ -13,6 +13,20 @@ There are two main components to Farser
     - Can be used to evaluate the boolean formula and interact with the evaluation
     - Can be used to iterate through the tree and print its representation
 
+
+**Limitations:**
+
+This library has its limitations. It can lex any desired string with minimal setup (it simply splits 
+the string to lex based on space delimiters), but building the AST has more limitations depending 
+on the current state of this library implementation. The currently known limitations are:
+
+ - Two operators next to each other are not possible. The formula is expected to alternate operand and operator
+    - for example in `COUNT > 0`, `COUNT` has to be an operand (a "variable" which will get substituted 
+      with some value) and it can not be an operator (an implementation of `TokenType`)
+ - It does not recognize any functions/operators with parameters 
+    - for example, `List(1, 2, 3)` will not build a proper AST
+
+
 ----
 
 ### Formula Lexer

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,11 @@ There are two main components to Farser
   - The Lexer - creates tokens from a String representation of a (DRG) formula
   - The Descent Parser - creates an Abstract Syntax Tree of boolean logic from the lexer tokens
     - Can be used to evaluate the boolean formula and interact with the evaluation
+    - Can be used to iterate through the tree and print its representation
 
 ----
 
-#### Formula Lexer
+### Formula Lexer
 
 The formula lexer simply splits a formula into well-defined elements (tokens). It recognizes 
 specific token types (defined as enum constants) and has a catch-all type called `ATOM` for
@@ -90,7 +91,8 @@ Syntax Tree, which can then be used to "evaluate" the expression against a list 
 AST contains the **boolean** logic of the formula and can evaluate a given list of operands to see 
 if the operands would evaluate to true or false.
 
-For a generic implementation which can produce an AST of your custom token types, see `AstDescentParser`.
+For a generic implementation which can produce an AST of your custom token types, see `AstDescentParser`. 
+The implementation needed for it [is described here](implementYourOwnAst.md).
 
 The purpose of the parser is not only to evaluate a formula (for which other approaches like 
 [Apache Commons JEXL](https://commons.apache.org/proper/commons-jexl/reference/examples.html#Evaluating_Expressions) 
@@ -110,6 +112,7 @@ top of the table an operator appears, the higher its precedence.
 | logical/binary AND |  &              |
 | logical/binary OR  |  \|             |
 
+For custom token implementations, the operator precedence can be defined in the `AstTokenType` interface.
 
 **Evaluation order:** Formula evaluation happens from left to right. Only relevant portions of the 
 formula will get evaluated (until a `true` result is achieved). See also: 
@@ -134,16 +137,18 @@ DescentParser<String> parser = new DescentParser<>(lexerTokens.listIterator(),
         new StringOperandSupplier(), suppliers);
 ```
 
-The above will use `String` objects in the terminal nodes of the AST for the boolean logic 
-evaluation.
+The above will use `String` objects as context data in the terminal nodes of the AST for the 
+boolean logic evaluation.
 
 ```Java 
 DescentParser<CustomTestOperand> parser = new DescentParser<>(lexerTokens.listIterator(),
         new CustomOperandSupplier(), customOperandSuppliers);
 ```
 
-The above will use `CustomTestOperand` objects in the terminal nodes of the AST for the boolean 
-logic evaluation.
+The above will use `CustomTestOperand` objects as context in the terminal nodes of the AST for 
+the boolean logic evaluation.
+
+The `AstDescentParser` goes one step further and allows any custom tokens to be built as AST.
 
 
 #### Descent parser BooleanExpression
@@ -164,32 +169,39 @@ expression must be evaluated and then return true or false. Farser provide a ver
 ```
 
 The above is rather simple and won't fit all use cases. In the event you need something more specific
-you can implement the `BooleanExpression` interface and provide an implementation for the 
-`evaluate` method.
+you can implement the `BooleanExpression` or `Expression` interfaces and provide an 
+implementation for the `evaluate` method.
 
 
 #### Descent parser suppliers
 
 The descent parser must be given the instructions for how to create terminal nodes. This is done
-using *Java suppliers*. A default node supplier must be given to the Descent parser, in the absence of
-specialty suppliers, the default supplier will be used to create a terminal node.
+using *Java suppliers*. A node supplier must be given to the Descent parser~~, in the absence of
+specialty suppliers, the default supplier will be used to create a terminal node~~.
 
-Speciality suppliers can be provided using a Map. When a terminal node is reached, the parser first
+Note: The "specialty suppliers" are deprecated. All needed logic plus more can be implemented in 
+the main supplier implementation.
+
+~~Speciality suppliers can be provided using a Map. When a terminal node is reached, the parser first
 checks for a special supplier for the token, if one is found, it will use the special supplier to 
-create the terminal node. This is how users can "supply" their own nodes to the parser. 
+create the terminal node. This is how users can "supply" their own nodes to the parser.~~
 
 A supplier for the AST must adhere to the `NodeSupplier` interface and provide an implementation of 
-the `BooleanExpression<R> createNode(T token);` method, where `T` is the token type and `R` is the
-type of (context) object to be used in the terminal nodes `BooleanExpression` (must match the generic 
-type of the DescentParser). Using this interface you can use _any_ object in the terminal nodes 
-`BooleanExpression` of the AST for a given token type. 
+the `Expression<C, ?> createNode(T token);` method, where `T` is the token type and `C` is the
+type of (context) object to be used in the `[Boolean]Expression`  terminal nodes (the type `C` must 
+match the generic type of the `[Ast]DescentParser`). Using this interface you can use _any_ object 
+in the terminal nodes `[Boolean]Expression` of the AST for a given token type. 
 
 ```Java
 private class StringOperandSupplier implements NodeSupplier<DrgLexerToken, String> {
 
     @Override
-    public BooleanExpression<String> createNode(DrgLexerToken token) {
-      return new ContainsNode<>(token.value);
+    public Expression<String, ?> createNode(DrgLexerToken token) {
+      if ("MY_FUNCTION".equals(token.getValue())) {
+        return new MySpecialFunctionNode();
+      } else {
+        return new ContainsNode<>(token.value);
+      }
     }
 }
 ```
@@ -216,8 +228,8 @@ private class CustomOperandSupplier implements NodeSupplier<DrgLexerToken, Custo
 ```java
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | C");    
     DescentParser<CustomTestOperand> parser = new DescentParser<>(lexerTokens.listIterator(),
-        new CustomOperandSupplier(), new HashMap<>());
-    DrgSyntaxTree<CustomTestOperand> ast = parser.buildExpressionTree();
+        new CustomOperandSupplier());
+    AbstractSyntaxTree<CustomTestOperand> ast = parser.buildTree();
 ```
 
 
@@ -229,15 +241,16 @@ private class CustomOperandSupplier implements NodeSupplier<DrgLexerToken, Custo
 
 #### Descent Parser ExpressionResult
 
-The return type from `DrgSyntaxTree#evaluateExpression` is an `ExpressionResult`. This class has 
+The return type from `AbstractSyntaxTree#evaluateExpression` is an `ExpressionResult`. This class has 
 two methods
 
   - `isMatched` - whether the boolean logic in the AST was satisfied with the list of 
     operands provided
-  - `getMatches` - the set of matched operands, which of the objects from the list of operands 
-    were used to satisfy the boolean logic of the AST. 
-    
-Users can query the expression result after the AST has been evaluated.
+  - `getContext` - to retrieve the context object which got passed into the `evaluateExpression` 
+    method and access data which may have been updated during the evaluation
+
+Since the `AbstractSyntaxTree` also itself is a non-terminal node, it also implements 
+`[Boolean]Expression` and the evaluation can alternatively be done by calling `AbstractSyntaxTree#evaluate`.
 
 When using custom tokens and/or custom a custom AST evaluation context object, the functionality may 
 vary. The used context can get accessed with `ExpressionResult#getContext()`. The context may get 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTree.java
@@ -2,7 +2,8 @@ package com.mmm.his.cer.utility.farser.ast;
 
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
-import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
 
 /**
@@ -12,20 +13,20 @@ import com.mmm.his.cer.utility.farser.ast.parser.ExpressionResult;
  * @author Mike Funaro
  * @author Thomas Naeff
  */
-public class AbstractSyntaxTree<C> extends NonTerminal<C> {
+public class AbstractSyntaxTree<C> extends BooleanNonTerminal<C> {
 
-  private BooleanExpression<C> ast;
+  private Expression<C, Boolean> ast;
 
-  public AbstractSyntaxTree(BooleanExpression<C> ast) {
+  public AbstractSyntaxTree(Expression<C, Boolean> ast) {
     this.ast = ast;
   }
 
-  public void setAst(BooleanExpression<C> ast) {
+  public void setAst(Expression<C, Boolean> ast) {
     this.ast = ast;
   }
 
   @Override
-  public boolean evaluate(C context) {
+  public Boolean evaluate(C context) {
     return this.ast.evaluate(context);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTreePrinter.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AbstractSyntaxTreePrinter.java
@@ -1,7 +1,7 @@
 package com.mmm.his.cer.utility.farser.ast;
 
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
-import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
@@ -24,7 +24,7 @@ public final class AbstractSyntaxTreePrinter {
 
   /**
    * Prints a simple tree representation.<br>
-   * Uses {@link #printNodeSimple(BooleanExpression)}.
+   * Uses {@link #printNodeSimple(Expression, AstPrinterContext)}.
    *
    * @param ast The AST
    * @return The tree representation as string
@@ -34,19 +34,18 @@ public final class AbstractSyntaxTreePrinter {
   }
 
   /**
-   *
    * Prints a tree representation based on the provided node printing function.
    *
    * @param ast       The AST to print
-   * @param printNode The function which determines how to print a node. The
-   *                  {@link BooleanExpression} function input may be <code>null</code> when the
-   *                  printing is past the last node (to possibly finalize/close data structures).
-   *                  See {@link #printNodeSimple(BooleanExpression, AstPrinterContext)} for a
-   *                  simple starting point.
-   * @return
+   * @param printNode The function which determines how to print a node. The {@link Expression}
+   *                  function input may be <code>null</code> when the printing is past the last
+   *                  node (to possibly finalize/close data structures). See
+   *                  {@link #printNodeSimple(Expression, AstPrinterContext)} for a simple starting
+   *                  point.
+   * @return The tree representation as string
    */
   public static <T> String printTree(AbstractSyntaxTree<T> ast,
-      Function<BooleanExpression<T>, String> printNode) {
+      Function<Expression<T, ?>, String> printNode) {
     return printTree(ast, DEFAULT_INDENTATION, (node, next) -> printNode.apply(node));
   }
 
@@ -54,15 +53,15 @@ public final class AbstractSyntaxTreePrinter {
    * Prints a simple tree representation.
    *
    * @param ast       The AST
-   * @param printNode The function which determines how to print a node. The
-   *                  {@link BooleanExpression} function input may be <code>null</code> when the
-   *                  printing is past the last node (to possibly finalize/close data structures).
-   *                  See {@link #printNodeSimple(BooleanExpression, AstPrinterContext)} for a
-   *                  simple starting point.
+   * @param printNode The function which determines how to print a node. The {@link Expression}
+   *                  function input may be <code>null</code> when the printing is past the last
+   *                  node (to possibly finalize/close data structures). See
+   *                  {@link #printNodeSimple(Expression, AstPrinterContext)} for a simple starting
+   *                  point.
    * @return The tree representation as string
    */
   public static <T> String printTree(AbstractSyntaxTree<T> ast,
-      BiFunction<BooleanExpression<T>, AstPrinterContext<T>, String> printNode) {
+      BiFunction<Expression<T, ?>, AstPrinterContext<T>, String> printNode) {
     return printTree(ast, DEFAULT_INDENTATION, printNode);
   }
 
@@ -70,15 +69,15 @@ public final class AbstractSyntaxTreePrinter {
    * Prints a simple tree representation.
    *
    * @param ast       The AST
-   * @param printNode The function which determines how to print a node. The
-   *                  {@link BooleanExpression} function input may be <code>null</code> when the
-   *                  printing is past the last node (to possibly finalize/close data structures).
-   *                  See {@link #printNodeSimple(BooleanExpression, AstPrinterContext)} for a
-   *                  simple starting point.
+   * @param printNode The function which determines how to print a node. The {@link Expression}
+   *                  function input may be <code>null</code> when the printing is past the last
+   *                  node (to possibly finalize/close data structures). See
+   *                  {@link #printNodeSimple(Expression, AstPrinterContext)} for a simple starting
+   *                  point.
    * @return The tree representation as string
    */
   public static <T> String printTree(AbstractSyntaxTree<T> ast, String indentation,
-      BiFunction<BooleanExpression<T>, AstPrinterContext<T>, String> printNode) {
+      BiFunction<Expression<T, ?>, AstPrinterContext<T>, String> printNode) {
     StringBuilder sb = new StringBuilder();
     int previousDepth = 0;
     int currentDepth = 0;
@@ -88,7 +87,7 @@ public final class AbstractSyntaxTreePrinter {
 
     while (iter.hasNext()) {
       // Need to get next first, so that depth of new/current node is available.
-      BooleanExpression<T> node = iter.next();
+      Expression<T, ?> node = iter.next();
       previousDepth = currentDepth;
       currentDepth = iter.getCurrentDepth();
 
@@ -119,12 +118,12 @@ public final class AbstractSyntaxTreePrinter {
    * @param context   The printer context
    */
   private static <T> void appendPrinted(StringBuilder sb,
-      BiFunction<BooleanExpression<T>, AstPrinterContext<T>, String> printNode,
-      BooleanExpression<T> node, AstPrinterContext<T> context) {
+      BiFunction<Expression<T, ?>, AstPrinterContext<T>, String> printNode,
+      Expression<T, ?> node, AstPrinterContext<T> context) {
     String printed = printNode.apply(node, context);
     // Do not add if printer function returned NULL. Documented behavior on this printer class
     // constructors.
-    if (printed != null ) {
+    if (printed != null) {
       sb.append(printed);
     }
   }
@@ -139,7 +138,7 @@ public final class AbstractSyntaxTreePrinter {
    */
   private static <T> AstPrinterContext<T> createPrinterContext(LtrExpressionIterator<T> iter,
       String prefix, int previousDepth) {
-    BooleanExpression<T> peeked = null;
+    Expression<T, ?> peeked = null;
     peeked = iter.hasNext() ? iter.peek() : null;
 
     int currentDepth = iter.getCurrentDepth();
@@ -191,7 +190,7 @@ public final class AbstractSyntaxTreePrinter {
    * @param node The node to print
    * @return The printed representation
    */
-  public static String printNodeSimple(BooleanExpression<?> node, AstPrinterContext<?> context) {
+  public static String printNodeSimple(Expression<?, ?> node, AstPrinterContext<?> context) {
     // Ignore any "closing" structure at the end of the tree.
     if (node == null) {
       return null;
@@ -205,12 +204,10 @@ public final class AbstractSyntaxTreePrinter {
   }
 
 
-  /***********************************************************************************************************************
-   *
+  /*************************************************************************************************
+   * A printer context to provide the printing function more details about the current state.
    *
    * @author Thomas Naeff
-   *
-   * @param <T>
    */
   public static class AstPrinterContext<T> {
 
@@ -246,10 +243,10 @@ public final class AbstractSyntaxTreePrinter {
      * The next node (peek). May be <code>null</code> when the iteration/printing is at or past the
      * last node.
      */
-    public final BooleanExpression<T> next;
+    public final Expression<T, ?> next;
 
     private AstPrinterContext(String prefix, int depth, AstPrintDirection direction,
-        BooleanExpression<T> next, int nextDepth, AstPrintDirection nextDirection) {
+        Expression<T, ?> next, int nextDepth, AstPrintDirection nextDirection) {
       this.depth = depth;
       this.nextDepth = nextDepth;
       this.prefix = prefix;

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AstCommonTokenType.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AstCommonTokenType.java
@@ -1,7 +1,16 @@
 package com.mmm.his.cer.utility.farser.ast;
 
 import com.mmm.his.cer.utility.farser.CommonTokenFlag;
+import com.mmm.his.cer.utility.farser.ast.node.type.NodeSupplier;
+import com.mmm.his.cer.utility.farser.ast.parser.AstDescentParser;
+import com.mmm.his.cer.utility.farser.lexer.LexerToken;
 
+/**
+ * Common token types for AST ({@link AstDescentParser}) logic.
+ *
+ * @author Thomas Naeff
+ *
+ */
 public enum AstCommonTokenType implements CommonTokenFlag {
 
   /**
@@ -20,13 +29,29 @@ public enum AstCommonTokenType implements CommonTokenFlag {
   NOT,
 
   /**
-   * A left-side assignment (e.g. <code>OR</code> operator).
+   * An "AND" operator.<br>
+   * <br>
+   * This flag exists for backwards compatibility when a {@link NodeSupplier} is used without the
+   * {@link NodeSupplier#createNonTerminalNode(LexerToken)} method being overridden.
+   *
+   * @deprecated Instead of using this flag, it is preferred to override
+   *             {@link NodeSupplier#createNonTerminalNode(LexerToken)} with your custom token
+   *             types.
    */
-  LEFT,
+  @Deprecated
+  AND,
 
   /**
-   * A right-side assignment (e.g. <code>AND</code> operator).
+   * An "OR" operator.<br>
+   * <br>
+   * This flag exists for backwards compatibility when a {@link NodeSupplier} is used without the
+   * {@link NodeSupplier#createNonTerminalNode(LexerToken)} method being overridden.
+   *
+   * @deprecated Instead of using this flag, it is preferred to override
+   *             {@link NodeSupplier#createNonTerminalNode(LexerToken)} with your custom token
+   *             types.
    */
-  RIGHT;
+  @Deprecated
+  OR;
 
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/AstTokenType.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/AstTokenType.java
@@ -1,0 +1,88 @@
+package com.mmm.his.cer.utility.farser.ast;
+
+import com.mmm.his.cer.utility.farser.lexer.TokenType;
+
+/**
+ * The interface to use for an enumeration which defines tokens that are recognized for AST
+ * generation this specific type of code (operand, operator, ...).<br />
+ * <br />
+ * Example:
+ *
+ * <pre>
+ * public enum DrgFormulaToken implements
+ *     TokenType&lt;DrgFormulaToken&gt;, AstTokenType&lt;DrgFormulaToken&gt; {
+ *
+ * ...
+ *
+ * }
+ * </pre>
+ *
+ *
+ * @param <T> The enumeration type which implements this interface.
+ * @author Mike Funaro
+ */
+public interface AstTokenType<T extends Enum<T>> extends TokenType<T> {
+  /**
+   * The value which is used by default for tokens which are not operators (and which therefore do
+   * not have an operator precedence set).
+   */
+  public static final int NOT_AN_OPERATOR = -1;
+
+  /**
+   * The precedence - or importance - of an operator which defines the order of operations (when no
+   * parenthesis define the order).<br>
+   * <br>
+   * A lower value means higher precedence (higher up in the hierarchy of importance, performed
+   * before an operation with a lower precedence).<br>
+   * A higher value means lower precedence (lower down in the hierarchy of importance, performed
+   * after an operation with a higher precedence).<br>
+   * <br>
+   * Operator precedence values must be > {@value #NOT_AN_OPERATOR}.<br>
+   * Multiple operators may have the same precedence value.<br>
+   * For tokens which are not an operator, return {@link #NOT_AN_OPERATOR}.
+   *
+   * @return The operator precedence, or {@link #NOT_AN_OPERATOR}.
+   */
+  int getOperatorPrecedence();
+
+  /**
+   * Checks if this token is an operator. It is considered an operator if an operator precedence is
+   * set.
+   *
+   * @return Whether or not this token is an operator.
+   */
+  default boolean isOperator() {
+    return getOperatorPrecedence() != NOT_AN_OPERATOR;
+  }
+
+  /**
+   * Checks whether the token is an operator (has a precedence set) and its precedence value is
+   * greater/equal the provided other precedence value.
+   *
+   * @param otherOperatorPrecedence The precedence value to test against
+   * @return <code>true</code> if lower/equal precedence (less importance/weight) compare to the
+   *         other
+   */
+  default boolean isLowerOrSamePrecedence(int otherOperatorPrecedence) {
+    // Higher value means lower precedence.
+    // Also handle equal precedence here.
+    int prec = getOperatorPrecedence();
+    return (prec != NOT_AN_OPERATOR) && (prec >= otherOperatorPrecedence);
+  }
+
+  /**
+   * Checks whether the token is an operator (has a precedence set) and its precedence value is less
+   * than the provided other precedence value.
+   *
+   * @param otherOperatorPrecedence The precedence value to test against
+   * @return <code>true</code> if higher precedence (more importance/weight) compare to the other
+   */
+  default boolean isHigherPrecedence(int otherOperatorPrecedence) {
+    // Lower value means higher precedence.
+    // Do not handle equal precedence here to get proper left-to-right evaluation when multiple
+    // operators with equal precedence follow each other.
+    int prec = getOperatorPrecedence();
+    return (prec != NOT_AN_OPERATOR) && (prec < otherOperatorPrecedence);
+  }
+
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/DrgSyntaxTree.java
@@ -1,19 +1,19 @@
 package com.mmm.his.cer.utility.farser.ast;
 
-import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 
 /**
- * Class that wraps a {@link BooleanExpression} and provides methods to evaluate it.
+ * Class that wraps a {@link Expression} and provides methods to evaluate it.
  *
  * @param <C> the type of context
  * @author Mike Funaro
- * @deprecated Use {@link AbstractSyntaxTree} instead for a non-DRG specific named class version with the
- *             exact same functionality.
+ * @deprecated Use {@link AbstractSyntaxTree} instead for a non-DRG specific named class version
+ *             with the exact same functionality.
  */
 @Deprecated
 public class DrgSyntaxTree<C> extends AbstractSyntaxTree<C> {
 
-  public DrgSyntaxTree(BooleanExpression<C> ast) {
+  public DrgSyntaxTree(Expression<C, Boolean> ast) {
     super(ast);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
@@ -1,6 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast.node;
 
-import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import java.util.Arrays;
 import java.util.Iterator;
 
@@ -14,20 +14,20 @@ import java.util.Iterator;
  *
  * @param <C> The expression context data type
  */
-public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> {
+public class LtrExpressionIterator<C> implements Iterator<Expression<C, ?>> {
 
   /**
    * The value returned by {@link #getPeekedDepth()} if {@link #peek()} has not been called yet.
    */
   public static final int PEEKED_DEPTH_NONE = -1;
 
-  private final Iterator<BooleanExpression<C>> nodes;
+  private final Iterator<Expression<C, ?>> nodes;
   private final int currentDepth;
   private Integer depthBeforePeek = null;
   private LtrExpressionIterator<C> currentIterator;
-  private BooleanExpression<C> peeked = null;
+  private Expression<C, ?> peeked = null;
 
-  private LtrExpressionIterator(int depth, Iterator<BooleanExpression<C>> nodes) {
+  private LtrExpressionIterator(int depth, Iterator<Expression<C, ?>> nodes) {
     this.currentDepth = depth;
     this.nodes = nodes;
   }
@@ -37,7 +37,7 @@ public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> 
   }
 
   @SafeVarargs
-  public LtrExpressionIterator(BooleanExpression<C>... nodes) {
+  public LtrExpressionIterator(Expression<C, ?>... nodes) {
     this(0, Arrays.asList(nodes).iterator());
   }
 
@@ -75,12 +75,12 @@ public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> 
   }
 
   @Override
-  public BooleanExpression<C> next() {
+  public Expression<C, ?> next() {
     // Only advance if not already done so by 'peek' for example.
     if (peeked == null) {
       return nextInternal();
     } else {
-      BooleanExpression<C> tmp = peeked;
+      Expression<C, ?> tmp = peeked;
       // Reset, to continue normal.
       peeked = null;
       depthBeforePeek = null;
@@ -88,7 +88,7 @@ public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> 
     }
   }
 
-  private BooleanExpression<C> nextInternal() {
+  private Expression<C, ?> nextInternal() {
     if ((currentIterator != null) && currentIterator.hasNext()) {
       // Iterate down the tree first
       return currentIterator.next();
@@ -97,7 +97,7 @@ public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> 
       currentIterator = null;
     }
 
-    BooleanExpression<C> current = nodes.next();
+    Expression<C, ?> current = nodes.next();
 
     // Keep node iterator for later to iterate down the tree.
     currentIterator = new LtrExpressionIterator<>(currentDepth + 1, current.iterator());
@@ -112,7 +112,7 @@ public class LtrExpressionIterator<C> implements Iterator<BooleanExpression<C>> 
    *
    * @return The next element in the iteration
    */
-  public BooleanExpression<C> peek() {
+  public Expression<C, ?> peek() {
     // Only peek if not already peeked.
     if (peeked == null) {
       depthBeforePeek = getCurrentDepthInternal();

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/And.java
@@ -1,6 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast.node.operator;
 
-import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
 
 /**
  * Implementation of a non-terminal node for use in the AST. This class represents a logical AND
@@ -9,10 +9,10 @@ import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
  * @param <C> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class And<C> extends NonTerminal<C> {
+public class And<C> extends BooleanNonTerminal<C> {
 
   @Override
-  public boolean evaluate(C context) {
+  public Boolean evaluate(C context) {
     // Evaluate left-side first, then right-side
     return left.evaluate(context) && right.evaluate(context);
   }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
@@ -1,7 +1,7 @@
 package com.mmm.his.cer.utility.farser.ast.node.operator;
 
-import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
-import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 
 /**
  * Implementation of a non-terminal node for use in the AST. This type of node will only have a left
@@ -10,28 +10,26 @@ import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
  * @param <C> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class Not<C> extends NonTerminal<C> {
+public class Not<C> extends BooleanNonTerminal<C> {
 
   /**
-   * For a not node, we should only set one child. This implementation allows to set the left child
+   * For a NOT node, we should only set one child. This implementation allows to set the left child
    * only. And should be the only public API for child setting of a Not node.
-   *
-   * @param child the child for this node.
    */
   @Override
-  public void setLeft(BooleanExpression<C> left) {
+  public void setLeft(Expression<C, Boolean> left) {
     // Overridden for updated javadoc.
     super.setLeft(left);
   }
 
   @Override
-  public void setRight(BooleanExpression<C> right) {
+  public void setRight(Expression<C, Boolean> right) {
     // Not nodes will only have one child and that is the left child. Throw error.
     throw new UnsupportedOperationException("Can only set the left-side child for NOT nodes");
   }
 
   @Override
-  public boolean evaluate(C context) {
+  public Boolean evaluate(C context) {
     boolean evaluation = left.evaluate(context);
     return !evaluation;
   }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Or.java
@@ -1,6 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast.node.operator;
 
-import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
 
 /**
  * Implementation of a non-terminal node for use in the AST. This class represents a logical OR
@@ -9,10 +9,10 @@ import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
  * @param <C> The context type used in the terminal nodes.
  * @author Mike Funaro
  */
-public class Or<C> extends NonTerminal<C> {
+public class Or<C> extends BooleanNonTerminal<C> {
 
   @Override
-  public boolean evaluate(C context) {
+  public Boolean evaluate(C context) {
     // Evaluate left-side first, then right-side
     return left.evaluate(context) || right.evaluate(context);
   }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/terminal/ContainsNode.java
@@ -20,7 +20,7 @@ public class ContainsNode<C extends Collection<A>, A> implements BooleanExpressi
   }
 
   @Override
-  public boolean evaluate(C context) {
+  public Boolean evaluate(C context) {
     return context.contains(this.value);
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanExpression.java
@@ -1,7 +1,5 @@
 package com.mmm.his.cer.utility.farser.ast.node.type;
 
-import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
-
 /**
  * Interface for each node of the AST to implement. This will allow the evaluation of the entire
  * boolean expression through recursion.
@@ -10,34 +8,16 @@ import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
  *
  * @author Mike Funaro
  */
-public interface BooleanExpression<C> extends Iterable<BooleanExpression<C>> {
+public interface BooleanExpression<C> extends Expression<C, Boolean> {
 
   /**
-   * Evaluate an expression returning true or false based on tests against the operands sent in.
+   * Evaluate an expression returning true or false based on tests against the operands sent in. The
+   * implementation should ensure that it never returns <code>null</code>.
    *
    * @param context The context that will be used in the evaluation of the node.
-   * @return <code>true</code> or <code>false</code>.
-   */
-  boolean evaluate(C context);
-
-  /**
-   * Returns an iterator over the expression elements.<br>
-   * <br>
-   * For terminal nodes, <code>null</code> should not be returned but an empty iterator can be
-   * returned (<code>return new ExpressionIterator<>()</code> - this default implementation).
+   * @return <code>true</code> or <code>false</code>. Never <code>null</code>.
    */
   @Override
-  default LtrExpressionIterator<C> iterator() {
-    return new LtrExpressionIterator<>();
-  }
-
-  /**
-   * Returns a printable representation of the node.
-   *
-   * @return The printable form of this node
-   */
-  default String print() {
-    return toString();
-  }
+  Boolean evaluate(C context);
 
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanNonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/BooleanNonTerminal.java
@@ -1,0 +1,17 @@
+package com.mmm.his.cer.utility.farser.ast.node.type;
+
+/**
+ * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
+ * right child, each of child individually with a boolean return type and with a combined evaluation
+ * result of a boolean type.
+ *
+ * @param <C> The node context type used in the terminal nodes.
+ * @author Mike Funaro
+ */
+public abstract class BooleanNonTerminal<C> extends NonTerminal<C, Boolean> {
+
+  @Override
+  public String toString() {
+    return "NonTerminal{" + "left=" + left + ", right=" + right + '}';
+  }
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/Expression.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/Expression.java
@@ -1,0 +1,45 @@
+package com.mmm.his.cer.utility.farser.ast.node.type;
+
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
+
+/**
+ * Interface for each node of the AST to implement. This will allow the evaluation of the entire
+ * boolean expression through recursion.
+ *
+ * @param <C> The type of context to be used for the terminal node execution.
+ * @param <R> The data type of the evaluation result
+ *
+ * @author Mike Funaro
+ * @author Thomas Naeff
+ */
+public interface Expression<C, R> extends Iterable<Expression<C, ?>> {
+
+  /**
+   * Evaluate an expression returning its value.
+   *
+   * @param context The context that will be used in the evaluation of the node.
+   * @return The expression result.
+   */
+  R evaluate(C context);
+
+  /**
+   * Returns an iterator over the expression elements.<br>
+   * <br>
+   * For terminal nodes, <code>null</code> should not be returned but an empty iterator can be
+   * returned (<code>return new ExpressionIterator<>()</code>, this default implementation).
+   */
+  @Override
+  default LtrExpressionIterator<C> iterator() {
+    return new LtrExpressionIterator<>();
+  }
+
+  /**
+   * Returns a printable representation of the node.
+   *
+   * @return The printable form of this node
+   */
+  default String print() {
+    return toString();
+  }
+
+}

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/type/NonTerminal.java
@@ -4,21 +4,34 @@ import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 
 /**
  * This class represents a non-terminal node in the AST. These types of nodes will have a left and a
- * right child.
+ * right child. Both child nodes have the same evaluation result (data) type, producing a combined
+ * boolean evaluation result type.
  *
  * @param <C> The node context type used in the terminal nodes.
- * @author Mike Funaro
+ * @param <E> The result type of each left/right expression
+ *
+ * @author Thomas Naeff
  */
-public abstract class NonTerminal<C> implements BooleanExpression<C> {
+public abstract class NonTerminal<C, E> implements BooleanExpression<C> {
 
-  protected BooleanExpression<C> left;
-  protected BooleanExpression<C> right;
+  protected Expression<C, E> left;
+  protected Expression<C, E> right;
 
-  public void setLeft(BooleanExpression<C> left) {
+  /**
+   * Sets the left-side child node.
+   *
+   * @param left The node to set
+   */
+  public void setLeft(Expression<C, E> left) {
     this.left = left;
   }
 
-  public void setRight(BooleanExpression<C> right) {
+  /**
+   * Sets the right-side child node.
+   *
+   * @param right The node to set
+   */
+  public void setRight(Expression<C, E> right) {
     this.right = right;
   }
 

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/Lexer.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/Lexer.java
@@ -29,7 +29,7 @@ public class Lexer {
    * @return List of {@link LexerToken} that were created from the input string.
    */
   public static <L extends LexerToken<T>, T extends TokenType<?>> List<L>
-  lex(Class<T> tokenTypeEnumClass, String input, LexerTokenFactory<L, T> factory) {
+      lex(Class<T> tokenTypeEnumClass, String input, LexerTokenFactory<L, T> factory) {
     List<L> result = new ArrayList<>();
     Pattern delimiterPattern = TokenType.createTokenPattern(tokenTypeEnumClass);
     Matcher delimiterMatcher = delimiterPattern.matcher(input);

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/TokenType.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/TokenType.java
@@ -6,8 +6,8 @@ import java.util.Optional;
 import java.util.regex.Pattern;
 
 /**
- * The interface to use for an enumeration which defines tokens that are recognized for this
- * specific type of code.<br />
+ * The interface to use for an enumeration which defines tokens that are recognized when lexing for
+ * this specific type of code (operand, operator, ...).<br />
  * <br />
  * Example:
  *

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/domain/DomainCodeToken.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/domain/DomainCodeToken.java
@@ -2,6 +2,7 @@ package com.mmm.his.cer.utility.farser.lexer.domain;
 
 import com.mmm.his.cer.utility.farser.CommonTokenFlag;
 import com.mmm.his.cer.utility.farser.ast.AstCommonTokenType;
+import com.mmm.his.cer.utility.farser.ast.AstTokenType;
 import com.mmm.his.cer.utility.farser.lexer.CommonTokenType;
 import com.mmm.his.cer.utility.farser.lexer.LexerToken;
 import com.mmm.his.cer.utility.farser.lexer.TokenType;
@@ -14,7 +15,7 @@ import java.util.Optional;
  *
  * @author Mike Funaro
  */
-public enum DomainCodeToken implements TokenType<DomainCodeToken> {
+public enum DomainCodeToken implements TokenType<DomainCodeToken>, AstTokenType<DomainCodeToken> {
 
   /**
    * Any substring which is not in a set of defined token characters here in {@link TokenType}. This
@@ -47,22 +48,22 @@ public enum DomainCodeToken implements TokenType<DomainCodeToken> {
   /**
    * A logical less-than-equal check (e.g. in an if-statement).
    */
-  LT_EQUAL("<="),
+  LT_EQUAL("<=", 1),
 
   /**
    * A logical greater-than-equal check (e.g. in an if-statement).
    */
-  GT_EQUAL(">="),
+  GT_EQUAL(">=", 1),
 
   /**
    * Logical AND.
    */
-  AND("and", AstCommonTokenType.RIGHT),
+  AND("and", AstCommonTokenType.AND, 3),
 
   /**
    * Logical OR.
    */
-  OR("or", AstCommonTokenType.LEFT),
+  OR("or", AstCommonTokenType.OR, 4),
 
   /**
    * Logical NOT.
@@ -77,17 +78,17 @@ public enum DomainCodeToken implements TokenType<DomainCodeToken> {
   /**
    * A logical is-equal check (e.g. in an if-statement).
    */
-  EQUAL("="),
+  EQUAL("=", 1),
 
   /**
    * A logical less-than check (e.g. in an if-statement).
    */
-  GREATER_THAN(">"),
+  GREATER_THAN(">", 1),
 
   /**
    * A logical greater-than check (e.g. in an if-statement).
    */
-  LESS_THAN("<"),
+  LESS_THAN("<", 1),
 
   /**
    * A pointer.
@@ -96,6 +97,7 @@ public enum DomainCodeToken implements TokenType<DomainCodeToken> {
 
   private final String value;
   private final CommonTokenFlag commonType;
+  private final int operatorPrecedence;
 
   /**
    * A new token type.
@@ -104,9 +106,29 @@ public enum DomainCodeToken implements TokenType<DomainCodeToken> {
    * @param commonType The common token type, or <code>null</code> if not needed
    */
   DomainCodeToken(String value, CommonTokenFlag commonType) {
+    this(value, commonType, AstTokenType.NOT_AN_OPERATOR);
+  }
+
+  /**
+   * A new token type - an operator with precedence.
+   *
+   * @param value              The token value, or <code>null</code> if not used
+   * @param operatorPrecedence The precedence of the operator
+   */
+  DomainCodeToken(String value, int operatorPrecedence) {
+    this(value, null, operatorPrecedence);
+  }
+
+  /**
+   * A new token type - an operator with precedence.
+   *
+   * @param value              The token value, or <code>null</code> if not used
+   * @param operatorPrecedence The precedence of the operator
+   */
+  DomainCodeToken(String value, CommonTokenFlag commonType, int operatorPrecedence) {
     this.value = value;
     this.commonType = commonType;
-
+    this.operatorPrecedence = operatorPrecedence;
   }
 
   /**
@@ -127,6 +149,11 @@ public enum DomainCodeToken implements TokenType<DomainCodeToken> {
   @Override
   public Optional<CommonTokenFlag> getCommonTokenType() {
     return Optional.ofNullable(commonType);
+  }
+
+  @Override
+  public int getOperatorPrecedence() {
+    return operatorPrecedence;
   }
 
 }

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/drg/DrgFormulaToken.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/drg/DrgFormulaToken.java
@@ -2,6 +2,7 @@ package com.mmm.his.cer.utility.farser.lexer.drg;
 
 import com.mmm.his.cer.utility.farser.CommonTokenFlag;
 import com.mmm.his.cer.utility.farser.ast.AstCommonTokenType;
+import com.mmm.his.cer.utility.farser.ast.AstTokenType;
 import com.mmm.his.cer.utility.farser.lexer.CommonTokenType;
 import com.mmm.his.cer.utility.farser.lexer.LexerToken;
 import com.mmm.his.cer.utility.farser.lexer.TokenType;
@@ -14,7 +15,7 @@ import java.util.Optional;
  *
  * @author Mike Funaro
  */
-public enum DrgFormulaToken implements TokenType<DrgFormulaToken> {
+public enum DrgFormulaToken implements TokenType<DrgFormulaToken>, AstTokenType<DrgFormulaToken> {
 
   /**
    * Any substring which is not in a set of defined token characters here in {@link TokenType}. This
@@ -42,12 +43,12 @@ public enum DrgFormulaToken implements TokenType<DrgFormulaToken> {
   /**
    * Logical AND.
    */
-  AND("&", AstCommonTokenType.RIGHT),
+  AND("&", AstCommonTokenType.AND, 1),
 
   /**
    * Logical OR.
    */
-  OR("|", AstCommonTokenType.LEFT),
+  OR("|", AstCommonTokenType.OR, 2),
 
   /**
    * Logical NOT.
@@ -56,6 +57,7 @@ public enum DrgFormulaToken implements TokenType<DrgFormulaToken> {
 
   private final String value;
   private final CommonTokenFlag commonType;
+  private final int operatorPrecedence;
 
   /**
    * A new token type.
@@ -64,9 +66,19 @@ public enum DrgFormulaToken implements TokenType<DrgFormulaToken> {
    * @param commonType The common token type, or <code>null</code> if not needed
    */
   DrgFormulaToken(String value, CommonTokenFlag commonType) {
+    this(value, commonType, AstTokenType.NOT_AN_OPERATOR);
+  }
+
+  /**
+   * A new token type - an operator with precedence.
+   *
+   * @param value              The token value, or <code>null</code> if not used
+   * @param operatorPrecedence The precedence of the operator
+   */
+  DrgFormulaToken(String value, CommonTokenFlag commonType, int operatorPrecedence) {
     this.value = value;
     this.commonType = commonType;
-
+    this.operatorPrecedence = operatorPrecedence;
   }
 
   /**
@@ -89,5 +101,9 @@ public enum DrgFormulaToken implements TokenType<DrgFormulaToken> {
     return Optional.ofNullable(commonType);
   }
 
+  @Override
+  public int getOperatorPrecedence() {
+    return operatorPrecedence;
+  }
 
 }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/AstTest.java
@@ -425,7 +425,7 @@ public class AstTest {
   }
 
   public static class StringOperandSupplier implements
-      NodeSupplier<DrgLexerToken, MaskedContext<String>> {
+  NodeSupplier<DrgLexerToken, MaskedContext<String>> {
 
     @Override
     public BooleanExpression<MaskedContext<String>> createNode(DrgLexerToken token) {
@@ -434,7 +434,7 @@ public class AstTest {
   }
 
   private static class CustomOperandSupplier implements
-      NodeSupplier<DrgLexerToken, MaskedContext<CustomTestOperand>> {
+  NodeSupplier<DrgLexerToken, MaskedContext<CustomTestOperand>> {
 
     @Override
     public BooleanExpression<MaskedContext<CustomTestOperand>> createNode(
@@ -445,7 +445,7 @@ public class AstTest {
   }
 
   private static class MsdrgGrouperFunctionSupplier implements
-      NodeSupplier<DrgLexerToken, MaskedContext<String>> {
+  NodeSupplier<DrgLexerToken, MaskedContext<String>> {
 
     private final List<String> otherInformation;
 
@@ -469,7 +469,7 @@ public class AstTest {
     }
 
     @Override
-    public boolean evaluate(MaskedContext<String> context) {
+    public Boolean evaluate(MaskedContext<String> context) {
       if (otherInformation.contains("luck")) {
         context.accumulate("luck");
         return true;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
-import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
@@ -201,7 +201,7 @@ public class LtrExpressionIteratorTest {
     // System.out.println(lexerTokens);
     AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
 
-    Iterator<BooleanExpression<MaskedContext<String>>> iter = ast.iterator();
+    Iterator<Expression<MaskedContext<String>, ?>> iter = ast.iterator();
 
     List<String> printed = new ArrayList<String>();
     while (iter.hasNext()) {

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
@@ -7,7 +7,8 @@ import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrintDire
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
 import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
-import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
@@ -83,7 +84,7 @@ public class PrintingJsonTest {
 
     private NodePrinterJson() {}
 
-    public String printNode(BooleanExpression<?> node, AstPrinterContext<?> printerContext) {
+    public String printNode(Expression<?, ?> node, AstPrinterContext<?> printerContext) {
       StringBuilder sb = new StringBuilder();
 
       if ((printerContext.direction == AstPrintDirection.UP) && !closingBrackets.isEmpty()) {
@@ -100,7 +101,7 @@ public class PrintingJsonTest {
 
       if (node != null) {
         // sb.append(String.format("%02d", printerContext.depth));
-        if ((node instanceof NonTerminal) && (printerContext.next instanceof NonTerminal)) {
+        if ((node instanceof BooleanNonTerminal) && (printerContext.next instanceof BooleanNonTerminal)) {
           sb.append(printerContext.prefix);
           // sb.append(node.getClass().getSimpleName());
           sb.append("\"");
@@ -108,7 +109,7 @@ public class PrintingJsonTest {
           sb.append("\": {");
           closingBrackets.add("}");
           sb.append(System.lineSeparator());
-        } else if ((node instanceof NonTerminal)
+        } else if ((node instanceof BooleanNonTerminal)
             && (printerContext.next instanceof BooleanExpression)) {
           sb.append(printerContext.prefix);
           // sb.append(node.getClass().getSimpleName());

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
 import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
-import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.ast.setup.TestContext;
@@ -54,8 +54,9 @@ public class PrintingTest {
   }
 
   @Test
-  public void testSimplestFormula1() throws Exception {
+  public void testSimplestFormula_reversedOperandPrecedence() throws Exception {
 
+    // OR is first in the formula, but should have a "weaker bond" than the AND
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A | B & C");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
         new StringOperandSupplier(), Collections.emptyMap());
@@ -77,8 +78,9 @@ public class PrintingTest {
   }
 
   @Test
-  public void testSimplestFormula2() throws Exception {
+  public void testSimplestFormula_leftToRightOperandPrecedence() throws Exception {
 
+    // The "stronger" AND operand appears first, then the "weaker" OR operand
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A & B | C");
     DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
         new StringOperandSupplier(), Collections.emptyMap());
@@ -188,13 +190,13 @@ public class PrintingTest {
      *                       skip evaluation
      * @return The node output
      */
-    public String printNode(BooleanExpression<T> node, AstPrinterContext<?> printerContext) {
+    public String printNode(Expression<T, ?> node, AstPrinterContext<?> printerContext) {
       StringBuilder sb = new StringBuilder();
       if (node != null) {
         sb.append(printerContext.prefix);
         sb.append(node.print());
         if (evaluationContext != null) {
-          boolean result = node.evaluate(evaluationContext);
+          Object result = node.evaluate(evaluationContext);
           sb.append(" = " + result);
         }
         sb.append(System.lineSeparator());
@@ -205,7 +207,7 @@ public class PrintingTest {
   }
 
 
-  public static String printNode(BooleanExpression<?> node, AstPrinterContext<?> printerContext) {
+  public static String printNode(Expression<?, ?> node, AstPrinterContext<?> printerContext) {
     if (node == null) {
       return null;
     }
@@ -219,7 +221,7 @@ public class PrintingTest {
     return sb.toString();
   }
 
-  public static String printNodeWithPeek(BooleanExpression<?> node,
+  public static String printNodeWithPeek(Expression<?, ?> node,
       AstPrinterContext<?> printerContext) {
     StringBuilder sb = new StringBuilder();
     // Print depth to ensure it does not get affected by the peek

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/ContainsNodeForContext.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/setup/ContainsNodeForContext.java
@@ -11,7 +11,7 @@ public class ContainsNodeForContext<T> implements BooleanExpression<MaskedContex
   }
 
   @Override
-  public boolean evaluate(MaskedContext<T> context) {
+  public Boolean evaluate(MaskedContext<T> context) {
     context.evaluating(value);
     if (context.getMask().contains(value)) {
       context.accumulate(value);

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/AstLimitationsTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/AstLimitationsTest.java
@@ -1,0 +1,73 @@
+package com.mmm.his.cer.utility.farser.ast_complex;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
+
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTree;
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter;
+import com.mmm.his.cer.utility.farser.ast.node.type.NodeSupplier;
+import com.mmm.his.cer.utility.farser.ast.parser.AstDescentParser;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ComplexTestTokenType;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.ComplexTestAstContext;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.ComplexTestAstNodeSupplier;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.lex.ComplexTestToken;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.lex.ComplexTestTokenFactory;
+import com.mmm.his.cer.utility.farser.lexer.FarserException;
+import com.mmm.his.cer.utility.farser.lexer.Lexer;
+import java.util.List;
+import org.junit.Test;
+
+
+/**
+ * The tests in here test the limitations of the AST - situations where the current implementation
+ * falls down just because it is not (yet) made for these scenarios.
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class AstLimitationsTest {
+
+  private static final ComplexTestTokenFactory factory = new ComplexTestTokenFactory();
+  private static final NodeSupplier<ComplexTestToken, ComplexTestAstContext> defaultNodeSupplier =
+      new ComplexTestAstNodeSupplier();
+
+
+  @Test
+  public void testTwoOperandsNextToEachOther() throws Exception {
+    // A formula for example to count based on a value and a lookup table.
+    // Since 'IN TABLE' is an operator and also '>' is an operator, AST building fails.
+    String input = "a IN TABLE > 5";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+
+    FarserException exc = assertThrows(FarserException.class, () -> parser.buildTree());
+    assertThat(exc.getMessage(), is("Expression malformed on token GT:>"));
+
+  }
+
+  @Test
+  public void doesNotProperlyWork_OperatorWithParameters() throws Exception {
+    // In this formula, the parenthesis are not recognised as operator parameter content.
+    String input = "a IN(1, 2, 3)";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "IN",
+        "  a",
+        "  1," // ... stuff is missing here
+    }));
+
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/ComplexFormulaAstTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/ComplexFormulaAstTest.java
@@ -1,0 +1,293 @@
+package com.mmm.his.cer.utility.farser.ast_complex;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTree;
+import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter;
+import com.mmm.his.cer.utility.farser.ast.PrintingTest;
+import com.mmm.his.cer.utility.farser.ast.node.type.NodeSupplier;
+import com.mmm.his.cer.utility.farser.ast.parser.AstDescentParser;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ComplexTestTokenType;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.ComplexTestAstContext;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ast.ComplexTestAstNodeSupplier;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.lex.ComplexTestToken;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.lex.ComplexTestTokenFactory;
+import com.mmm.his.cer.utility.farser.lexer.Lexer;
+import java.util.List;
+import org.junit.Test;
+
+public class ComplexFormulaAstTest {
+
+  private static final ComplexTestTokenFactory factory = new ComplexTestTokenFactory();
+  private static final NodeSupplier<ComplexTestToken, ComplexTestAstContext> defaultNodeSupplier =
+      new ComplexTestAstNodeSupplier();
+
+
+  @Test
+  public void simpleTwoExpressionsGreaterThanAnd() throws Exception {
+    String input = "A > 5 & B = 2";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "AND",
+        "  GREATER-THAN",
+        "    A",
+        "    5",
+        "  EQUAL",
+        "    B",
+        "    2"
+    }));
+
+  }
+
+  @Test
+  public void simpleTwoExpressionsGreaterLessThanAndOr() throws Exception {
+    String input = "A = 1 & B > 5 | C < 2";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "OR",
+        "  AND",
+        "    EQUAL",
+        "      A",
+        "      1",
+        "    GREATER-THAN",
+        "      B",
+        "      5",
+        "  LESS-THAN",
+        "    C",
+        "    2"
+    }));
+
+  }
+
+  @Test
+  public void simpleTwoExpressionsGreaterLessThanAndOr_andOrOrderSwapped() throws Exception {
+    String input = "A = 1 | B > 5 & C < 2";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "OR",
+        "  EQUAL",
+        "    A",
+        "    1",
+        "  AND",
+        "    GREATER-THAN",
+        "      B",
+        "      5",
+        "    LESS-THAN",
+        "      C",
+        "      2"
+    }));
+
+  }
+
+  @Test
+  public void testMultipleOperatorsWithSamePrecedence() throws Exception {
+
+    // Do two greather-than signs following each other make sense? Not necessarily - different
+    // programming languages seem to handle such a case differently (some allow it and it means "3 >
+    // 2 && 2 > 1", others fail to compile). In any case, the purpose of this is to ensure that
+    // operators with same precedence still evaluate the left-side part first, then the right-side
+    // part.
+    List<ComplexTestToken> lexerTokens =
+        Lexer.lex(ComplexTestTokenType.class, "3 > 2 > 1", factory);
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser = new AstDescentParser<>(
+        lexerTokens.listIterator(), defaultNodeSupplier);
+
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "GREATER-THAN",
+        "  GREATER-THAN",
+        "    3",
+        "    2",
+        "  1"
+    }));
+
+  }
+
+  @Test
+  public void testMultipleOperatorsWithSamePrecedencePlusBoolean() throws Exception {
+
+    // Two ">" operators which have the same precedence, connected with "AND". Should properly
+    // build the AST left-to-right.
+    List<ComplexTestToken> lexerTokens =
+        Lexer.lex(ComplexTestTokenType.class, "3 > 2 & 2 > 1", factory);
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(
+            lexerTokens.listIterator(), defaultNodeSupplier);
+
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "AND",
+        "  GREATER-THAN",
+        "    3",
+        "    2",
+        "  GREATER-THAN",
+        "    2",
+        "    1",
+    }));
+
+  }
+
+  @Test
+  public void testSimplestFormula_reversedOperandPrecedence() throws Exception {
+
+    // OR is first in the formula, but should have a "weaker bond" than the AND
+    List<ComplexTestToken> lexerTokens = Lexer.lex(ComplexTestTokenType.class, "A | B & C", factory);
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser = new AstDescentParser<>(
+        lexerTokens.listIterator(), defaultNodeSupplier);
+
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNode);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR",
+        "02  A",
+        "02  AND",
+        "03    B",
+        "03    C"
+    }));
+
+  }
+
+  @Test
+  public void testSimplestFormula_leftToRightOperandPrecedence() throws Exception {
+
+    // The "stronger" AND operand appears first, then the "weaker" OR operand
+    List<ComplexTestToken> lexerTokens = Lexer.lex(ComplexTestTokenType.class, "A & B | C", factory);
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser = new AstDescentParser<>(
+        lexerTokens.listIterator(), defaultNodeSupplier);
+
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNode);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR",
+        "02  AND",
+        "03    A",
+        "03    B",
+        "02  C"
+    }));
+
+  }
+
+  @Test
+  public void testPrintTreeWithPeek() throws Exception {
+
+    List<ComplexTestToken> lexerTokens =
+        Lexer.lex(ComplexTestTokenType.class, "(A & B | C) & D | (E & F)", factory);
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser = new AstDescentParser<>(
+        lexerTokens.listIterator(), defaultNodeSupplier);
+
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNodeWithPeek);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR next=AND",
+        "02  AND next=OR",
+        "03    OR next=AND",
+        "04      AND next=A",
+        "05        A next=B",
+        "05        B next=C",
+        "04      C next=D",
+        "03    D next=AND",
+        "02  AND next=E",
+        "03    E next=F",
+        "03    F next=NONE",
+        "03    ", // Including the "closing" structure of each node
+        "02  ",
+        "01"
+    }));
+
+  }
+
+  @Test
+  public void twoWordTokenWithOneWordAmbiguity() throws Exception {
+    // Token "IN TABLE" could also get recognized as "IN", but it should get resolved as "IN TABLE"
+    String input = "a IN TABLE abc";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "IN-TABLE",
+        "  a",
+        "  abc"
+    }));
+
+  }
+
+  @Test
+  public void singleWordTokenWithTwoWordAmbiguity() throws Exception {
+    // Token "IN" also exists as "IN TABLE", but it should get resolved as "IN"
+    String input = "a IN abc";
+    List<ComplexTestToken> tokens = Lexer.lex(ComplexTestTokenType.class, input, factory);
+
+    AstDescentParser<ComplexTestToken, ComplexTestTokenType, ComplexTestAstContext> parser =
+        new AstDescentParser<>(tokens.iterator(), defaultNodeSupplier);
+    AbstractSyntaxTree<ComplexTestAstContext> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast);
+    String[] lines = printed.split(System.lineSeparator());
+
+    // System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "IN",
+        "  a",
+        "  abc"
+    }));
+
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ComplexTestTokenType.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ComplexTestTokenType.java
@@ -1,0 +1,77 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup;
+
+import com.mmm.his.cer.utility.farser.CommonTokenFlag;
+import com.mmm.his.cer.utility.farser.ast.AstCommonTokenType;
+import com.mmm.his.cer.utility.farser.ast.AstTokenType;
+import com.mmm.his.cer.utility.farser.lexer.CommonTokenType;
+import com.mmm.his.cer.utility.farser.lexer.TokenType;
+import java.util.Optional;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ */
+public enum ComplexTestTokenType
+    implements
+    TokenType<ComplexTestTokenType>,
+    AstTokenType<ComplexTestTokenType> {
+
+  ATOM(null, CommonTokenType.ATOM),
+  SPACE(" ", CommonTokenType.SPACE),
+  LPAREN("(", AstCommonTokenType.LPAREN),
+  RPAREN(")", AstCommonTokenType.RPAREN),
+  NOT("!", AstCommonTokenType.NOT),
+
+  IF("IF"),
+  THEN("THEN"),
+  ELSE("ELSE"),
+  ELSEIF("ELSE IF"),
+  ENDIF("ENDIF"),
+
+  // Operator precedence: Lower value = stronger bond
+  GT(">", 1),
+  LT("<", 1),
+  EQUAL("=", 2),
+  AND("&", 3),
+  OR("|", 4),
+
+  IN("IN", 1),
+  IN_TABLE("IN TABLE", 1);
+
+  private final String value;
+  private final CommonTokenFlag commonType;
+  private final int operatorPrecedence;
+
+  ComplexTestTokenType(String value, CommonTokenFlag commonType) {
+    this.value = value;
+    this.commonType = commonType;
+    this.operatorPrecedence = AstTokenType.NOT_AN_OPERATOR;
+  }
+
+  ComplexTestTokenType(String value, int operatorPrecedence) {
+    this.value = value;
+    this.commonType = null;
+    this.operatorPrecedence = operatorPrecedence;
+  }
+
+  ComplexTestTokenType(String value) {
+    this(value, null);
+  }
+
+  @Override
+  public Optional<String> getValue() {
+    return Optional.ofNullable(value);
+  }
+
+  @Override
+  public Optional<CommonTokenFlag> getCommonTokenType() {
+    return Optional.ofNullable(commonType);
+  }
+
+  @Override
+  public int getOperatorPrecedence() {
+    return operatorPrecedence;
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestAstContext.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestAstContext.java
@@ -1,0 +1,5 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+public class ComplexTestAstContext {
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestAstNodeSupplier.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestAstNodeSupplier.java
@@ -1,0 +1,47 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.operator.And;
+import com.mmm.his.cer.utility.farser.ast.node.operator.Not;
+import com.mmm.his.cer.utility.farser.ast.node.operator.Or;
+import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
+import com.mmm.his.cer.utility.farser.ast.node.type.NodeSupplier;
+import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.lex.ComplexTestToken;
+import com.mmm.his.cer.utility.farser.lexer.FarserException;
+
+public class ComplexTestAstNodeSupplier implements NodeSupplier<ComplexTestToken, ComplexTestAstContext> {
+
+  @Override
+  public Expression<ComplexTestAstContext, ?> createNode(final ComplexTestToken inToken) {
+    return new ComplexTestTerminalNode(inToken);
+  }
+
+
+  @Override
+  public NonTerminal<ComplexTestAstContext, ?> createNonTerminalNode(ComplexTestToken token) {
+
+    switch (token.type) {
+      case GT:
+        return new ComplexTestGreaterThanOperator<>();
+      case LT:
+        return new ComplexTestLessThanOperator<>();
+      case EQUAL:
+        return new ComplexTestEqualOperator<>();
+      case AND:
+        return new And<>();
+      case OR:
+        return new Or<>();
+      case NOT:
+        return new Not<>();
+      case IN:
+        return new ComplexTestInOperator<>();
+      case IN_TABLE:
+        return new ComplexTestInTableOperator<>();
+      default:
+        throw new FarserException("Operator type " + token + " not implemented");
+    }
+
+  }
+
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestEqualOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestEqualOperator.java
@@ -1,0 +1,31 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ * @param <C>
+ */
+public class ComplexTestEqualOperator<C> extends NonTerminal<C, Integer> {
+
+  @Override
+  public Boolean evaluate(C context) {
+    Integer leftResult = left.evaluate(context);
+    Integer rightResult = left.evaluate(context);
+    // NPE save 'equals'
+    return leftResult == null ? leftResult == rightResult : leftResult.equals(rightResult);
+  }
+
+  @Override
+  public String print() {
+    return "EQUAL";
+  }
+
+  @Override
+  public String toString() {
+    return "Equal{" + "left=" + left + ", right=" + right + '}';
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestGreaterThanOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestGreaterThanOperator.java
@@ -1,0 +1,28 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ * @param <C>
+ */
+public class ComplexTestGreaterThanOperator<C> extends NonTerminal<C, Integer> {
+
+  @Override
+  public Boolean evaluate(C context) {
+    return left.evaluate(context) > right.evaluate(context);
+  }
+
+  @Override
+  public String print() {
+    return "GREATER-THAN";
+  }
+
+  @Override
+  public String toString() {
+    return "GreaterThan{" + "left=" + left + ", right=" + right + '}';
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestInOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestInOperator.java
@@ -1,0 +1,29 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ * @param <C>
+ */
+public class ComplexTestInOperator<C> extends NonTerminal<C, String> {
+
+  @Override
+  public Boolean evaluate(C context) {
+    // Just some dummy "in" evaluation
+    return right.evaluate(context).contains(left.evaluate(context));
+  }
+
+  @Override
+  public String print() {
+    return "IN";
+  }
+
+  @Override
+  public String toString() {
+    return "In{" + "left=" + left + ", right=" + right + '}';
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestInTableOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestInTableOperator.java
@@ -1,0 +1,29 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ * @param <C>
+ */
+public class ComplexTestInTableOperator<C> extends NonTerminal<C, String> {
+
+  @Override
+  public Boolean evaluate(C context) {
+    // Just some dummy "in table" evaluation
+    return right.evaluate(context).contains(left.evaluate(context));
+  }
+
+  @Override
+  public String print() {
+    return "IN-TABLE";
+  }
+
+  @Override
+  public String toString() {
+    return "InTable{" + "left=" + left + ", right=" + right + '}';
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestLessThanOperator.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestLessThanOperator.java
@@ -1,0 +1,28 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.NonTerminal;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ * @param <C>
+ */
+public class ComplexTestLessThanOperator<C> extends NonTerminal<C, Integer> {
+
+  @Override
+  public Boolean evaluate(C context) {
+    return left.evaluate(context) < right.evaluate(context);
+  }
+
+  @Override
+  public String print() {
+    return "LESS-THAN";
+  }
+
+  @Override
+  public String toString() {
+    return "LessThan{" + "left=" + left + ", right=" + right + '}';
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestTerminalNode.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/ast/ComplexTestTerminalNode.java
@@ -1,0 +1,35 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.ast;
+
+import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
+import com.mmm.his.cer.utility.farser.ast_complex.setup.lex.ComplexTestToken;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class ComplexTestTerminalNode implements BooleanExpression<ComplexTestAstContext> {
+
+  private final ComplexTestToken token;
+
+  public ComplexTestTerminalNode(ComplexTestToken token) {
+    this.token = token;
+  }
+
+  @Override
+  public Boolean evaluate(ComplexTestAstContext context) {
+    return Boolean.valueOf(token.getValue());
+  }
+
+  @Override
+  public String print() {
+    return token.value;
+  }
+
+  @Override
+  public String toString() {
+    return token.value;
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/lex/ComplexTestToken.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/lex/ComplexTestToken.java
@@ -1,0 +1,37 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.lex;
+
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ComplexTestTokenType;
+import com.mmm.his.cer.utility.farser.lexer.LexerToken;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class ComplexTestToken implements LexerToken<ComplexTestTokenType> {
+
+  public final ComplexTestTokenType type;
+  public final String value;
+
+  public ComplexTestToken(ComplexTestTokenType type, String value) {
+    this.type = type;
+    this.value = value;
+  }
+
+  @Override
+  public ComplexTestTokenType getType() {
+    return type;
+  }
+
+  @Override
+  public String getValue() {
+    return value;
+  }
+
+  @Override
+  public String toString() {
+    return type + ":" + value;
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/lex/ComplexTestTokenFactory.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast_complex/setup/lex/ComplexTestTokenFactory.java
@@ -1,0 +1,23 @@
+package com.mmm.his.cer.utility.farser.ast_complex.setup.lex;
+
+import com.mmm.his.cer.utility.farser.ast_complex.setup.ComplexTestTokenType;
+import com.mmm.his.cer.utility.farser.lexer.LexerTokenFactory;
+
+/**
+ *
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class ComplexTestTokenFactory implements LexerTokenFactory<ComplexTestToken, ComplexTestTokenType> {
+
+  @Override
+  public ComplexTestToken create(ComplexTestTokenType tokenType, String value) {
+    if (tokenType == ComplexTestTokenType.SPACE) {
+      // Ignore spaces
+      return null;
+    }
+
+    return new ComplexTestToken(tokenType, value);
+  }
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/lexer/LexerWithOnlyAtomTokensTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/lexer/LexerWithOnlyAtomTokensTest.java
@@ -1,0 +1,120 @@
+package com.mmm.his.cer.utility.farser.lexer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
+
+import com.mmm.his.cer.utility.farser.CommonTokenFlag;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.Test;
+
+/**
+ * This test demonstrates that only the minimally required token types (all the ones in
+ * {@link CommonTokenType}) are needed to lex any kind of string.
+ *
+ * @author Thomas Naeff
+ *
+ */
+public class LexerWithOnlyAtomTokensTest {
+
+  private static final MyOwnTokenFactory factory = new MyOwnTokenFactory();
+
+  @Test
+  public void allAtomTokensWithNoSpecificTypes() throws Exception {
+
+    String toLex = "a b / ( c this works well";
+
+    List<MyOwnToken> lexed = Lexer.lex(EmptyTokenType.class, toLex, factory);
+
+    List<String> toTest = lexed.stream()
+        .map(token -> token.getType() + ":" + token.getValue())
+        .collect(Collectors.toList());
+    assertThat(toTest, contains("ATOM:a", "ATOM:b", "ATOM:/", "ATOM:(", "ATOM:c", "ATOM:this",
+        "ATOM:works", "ATOM:well"));
+
+  }
+
+
+
+  /*******************************************************************************************
+   *
+   * @author Thomas Naeff
+   *
+   */
+  private enum EmptyTokenType implements TokenType<EmptyTokenType> {
+
+    SPACE(CommonTokenType.SPACE),
+    ATOM(CommonTokenType.ATOM);
+
+    // No further enum elements here aside from the mandatory ones.
+
+    private final CommonTokenType commonType;
+
+    EmptyTokenType(CommonTokenType commonType) {
+      this.commonType = commonType;
+    }
+
+    @Override
+    public Optional<String> getValue() {
+      return Optional.empty();
+    }
+
+    @Override
+    public Optional<CommonTokenFlag> getCommonTokenType() {
+      return Optional.of(commonType);
+    }
+
+  }
+
+  /*******************************************************************************************
+   *
+   * @author Thomas Naeff
+   *
+   */
+  private static class MyOwnToken implements LexerToken<EmptyTokenType> {
+
+    public final EmptyTokenType type;
+    public final String value;
+
+    public MyOwnToken(EmptyTokenType type, String value) {
+      this.type = type;
+      this.value = value;
+    }
+
+    @Override
+    public EmptyTokenType getType() {
+      return type;
+    }
+
+    @Override
+    public String getValue() {
+      return value;
+    }
+
+    @Override
+    public String toString() {
+      return value;
+    }
+
+  }
+
+  /*******************************************************************************************
+   *
+   * @author Thomas Naeff
+   *
+   */
+  private static class MyOwnTokenFactory implements LexerTokenFactory<MyOwnToken, EmptyTokenType> {
+
+    @Override
+    public MyOwnToken create(EmptyTokenType tokenType, String value) {
+      if (tokenType == EmptyTokenType.SPACE) {
+        // Ignore spaces
+        return null;
+      }
+
+      return new MyOwnToken(tokenType, value);
+    }
+  }
+
+}

--- a/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/TestToken.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/TestToken.java
@@ -93,5 +93,4 @@ public enum TestToken implements TokenType<TestToken> {
     return commonType;
   }
 
-
 }

--- a/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/TestTokenWithoutMandatoryAtom.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/TestTokenWithoutMandatoryAtom.java
@@ -67,5 +67,4 @@ public enum TestTokenWithoutMandatoryAtom implements TokenType<TestTokenWithoutM
     return commonType;
   }
 
-
 }

--- a/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/TestTokenWithoutMandatorySpace.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/lexer/tokentype/TestTokenWithoutMandatorySpace.java
@@ -61,5 +61,4 @@ public enum TestTokenWithoutMandatorySpace implements TokenType<TestTokenWithout
     return commonType;
   }
 
-
 }


### PR DESCRIPTION
This update opens up the functionality for defining any kind of operator (not just boolean operators). In addition, each operator can have a precedence which is now needed when having more than just OR/AND to choose from.

--------

The main change was the introduction of the `Expression` interface which now allows the evaluation return type to be anything else than boolean. This interface now replaces `BooleanExpression` throughout the code in most places. Other than that, this interface is an exact copy of the existing `BooleanExpression`. Since the evaluation return type is not a primitive any more, the `BooleanExpression` javadoc states that it should never return null.

The `NonTerminal` interface can now take any left- or right-side evaluation data type (e.g. an operation between two integers). The `BooleanNonTerminal` represents the previous node with a boolean return type for both sides.

Since now new custom operands are possible, the non-terminal nodes `And` and `Or` do not cover all cases any more. The `NodeSupplier#createNonTerminalNode` method allows the user to supply their operand implementations.

The `AstDescentParser` got updated to handle operator precedence. Only a few changes were needed, the general `expression`, `term` and `factor` approaches were left unchanged. 
- `term` now calls `term` recursively instead of calling `factor` (since we can have a left and right term, not just a boolean variable)
- The `while` statement does not compare token types any more, it now compares operator precedence
- Some "unchecked casts" are now needed since it can not be guaranteed that two nodes match with their evaluation return type. This is however just the nature of the dynamic possibility to allow any node and operation. Each node could also have `Object` data/evaluation types which would eliminate the need for casting, but then the implementation of each node would not be type safe any more.

Quite some documentation got updated and added. Also javadoc.

Checkstyle issues have been fixed.

--------

**Potentially breaking changes:**
*"Potentially breaking" because the currently used implementations use the `lexer.drg.*` implementations which are contained in this project and have already been updated based on these changes.*

- `NonTerminal` renamed to `BooleanNonTerminal` (to match `BooleanExpression` and due to new more generic `NonTerminal`)
- New `NonTerminal` implementation with two more generic parameters `E` and `R` to allow for any non-boolean operators (greater/less-than, equal, ...)
- Use of `Expression<C, Boolean>` or `Expression<C, ?>` in most places instead of `BooleanExpression<C>` for various input parameters and output types
- `TokenType` has a new method `getOperatorPrecedence` which needs to get implemented. It is documented that it may return  `TokenType.NOT_AN_OPERATOR` if not needed.