### PR TITLE
Fixed iteration for not

### DIFF
--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/LtrExpressionIterator.java
@@ -3,6 +3,7 @@ package com.mmm.his.cer.utility.farser.ast.node;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * An iterator which iterates over the complete expression, top down (starting at the root node) and
@@ -36,9 +37,24 @@ public class LtrExpressionIterator<C> implements Iterator<Expression<C, ?>> {
     this(depth, copy.nodes);
   }
 
+
+  /**
+   * An iterator over the provided list of nodes (and recursively into their child nodes).
+   *
+   * @param nodes The list of nodes. None of the elements may be <code>null</code>.
+   */
+  public LtrExpressionIterator(List<Expression<C, ?>> nodes) {
+    this(0, nodes.iterator());
+  }
+
+  /**
+   * An iterator over the provided list of nodes (and recursively into their child nodes).
+   *
+   * @param nodes The list of nodes. None of the elements may be <code>null</code>.
+   */
   @SafeVarargs
   public LtrExpressionIterator(Expression<C, ?>... nodes) {
-    this(0, Arrays.asList(nodes).iterator());
+    this(Arrays.asList(nodes));
   }
 
   /**
@@ -98,9 +114,18 @@ public class LtrExpressionIterator<C> implements Iterator<Expression<C, ?>> {
     }
 
     Expression<C, ?> current = nodes.next();
+    int nextDepth = currentDepth + 1;
+
+    if (current == null) {
+      throw new NullPointerException("A node is NULL (when recursing from depth "
+          + currentDepth
+          + " to depth "
+          + nextDepth
+          + ")");
+    }
 
     // Keep node iterator for later to iterate down the tree.
-    currentIterator = new LtrExpressionIterator<>(currentDepth + 1, current.iterator());
+    currentIterator = new LtrExpressionIterator<>(nextDepth, current.iterator());
 
     return current;
   }

--- a/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/ast/node/operator/Not.java
@@ -1,5 +1,6 @@
 package com.mmm.his.cer.utility.farser.ast.node.operator;
 
+import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 
@@ -32,6 +33,11 @@ public class Not<C> extends BooleanNonTerminal<C> {
   public Boolean evaluate(C context) {
     boolean evaluation = left.evaluate(context);
     return !evaluation;
+  }
+
+  @Override
+  public LtrExpressionIterator<C> iterator() {
+    return new LtrExpressionIterator<>(left);
   }
 
   @Override

--- a/src/main/java/com/mmm/his/cer/utility/farser/lexer/FarserException.java
+++ b/src/main/java/com/mmm/his/cer/utility/farser/lexer/FarserException.java
@@ -19,4 +19,14 @@ public class FarserException extends RuntimeException {
     super(message);
   }
 
+  /**
+   * A new exception.
+   *
+   * @param message The exception message
+   * @param thrw    The causing exception
+   */
+  public FarserException(String message, Throwable thrw) {
+    super(message, thrw);
+  }
+
 }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/AstEvaluationTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/AstEvaluationTest.java
@@ -26,7 +26,7 @@ import org.junit.Test;
 /**
  * @author Mike Funaro
  */
-public class AstTest {
+public class AstEvaluationTest {
 
   final Map<String, NodeSupplier<DrgLexerToken, MaskedContext<String>>> suppliers = new HashMap<>();
   final Map<String, NodeSupplier<DrgLexerToken, MaskedContext<CustomTestOperand>>> customOperandSuppliers =

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/AstEvaluationTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/AstEvaluationTest.java
@@ -424,7 +424,7 @@ public class AstEvaluationTest {
     }
   }
 
-  public static class StringOperandSupplier implements
+  private static class StringOperandSupplier implements
   NodeSupplier<DrgLexerToken, MaskedContext<String>> {
 
     @Override

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -5,11 +5,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertThrows;
 
-import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.setup.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
 import java.util.ArrayList;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertThrows;
 
-import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.LtrExpressionIterator;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/LtrExpressionIteratorTest.java
@@ -271,4 +271,39 @@ public class LtrExpressionIteratorTest {
 
   }
 
+  @Test
+  public void testNegatedOperandsIterator() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("~A & ~B");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    // System.out.println(lexerTokens);
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    LtrExpressionIterator<MaskedContext<String>> iter = ast.iterator();
+
+    assertThat(iter.hasNext(), is(true));
+    assertThat(iter.getCurrentDepth(), is(0));
+
+    assertThat(iter.next().print(), is("AND"));
+    assertThat(iter.getCurrentDepth(), is(1));
+
+    assertThat(iter.next().print(), is("NOT"));
+    assertThat(iter.getCurrentDepth(), is(2));
+
+    assertThat(iter.next().print(), is("A"));
+    assertThat(iter.getCurrentDepth(), is(3));
+
+    assertThat(iter.next().print(), is("NOT"));
+    assertThat(iter.getCurrentDepth(), is(2));
+
+    assertThat(iter.next().print(), is("B"));
+    assertThat(iter.getCurrentDepth(), is(3));
+
+    assertThrows(NoSuchElementException.class, iter::next);
+    assertThat(iter.hasNext(), is(false));
+
+  }
+
 }

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
@@ -3,9 +3,9 @@ package com.mmm.his.cer.utility.farser.ast;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.setup.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.setup.TestContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/OperandAndEvaluationOrderTest.java
@@ -3,7 +3,7 @@ package com.mmm.his.cer.utility.farser.ast;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 
-import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
 import com.mmm.his.cer.utility.farser.ast.setup.TestContext;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
@@ -5,12 +5,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrintDirection;
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
-import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.setup.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;
 import java.util.Collections;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingJsonTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrintDirection;
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
-import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanExpression;
 import com.mmm.his.cer.utility.farser.ast.node.type.BooleanNonTerminal;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
@@ -102,6 +102,30 @@ public class PrintingTest {
   }
 
   @Test
+  public void testNegatedVariables() throws Exception {
+
+    List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("A & ~B | C");
+    DescentParser<MaskedContext<String>> parser = new DescentParser<>(lexerTokens.listIterator(),
+        new StringOperandSupplier(), Collections.emptyMap());
+
+    AbstractSyntaxTree<MaskedContext<String>> ast = parser.buildTree();
+
+    String printed = AbstractSyntaxTreePrinter.printTree(ast, PrintingTest::printNode);
+    String[] lines = printed.split(System.lineSeparator());
+
+    System.out.println(printed);
+    assertThat(lines, is(new String[] {
+        "01OR",
+        "02  AND",
+        "03    A",
+        "03    NOT",
+        "04      B",
+        "02  C"
+    }));
+
+  }
+
+  @Test
   public void testPrintTreeWithPeek() throws Exception {
 
     List<DrgLexerToken> lexerTokens = DrgFormulaLexer.lex("(A & B | C) & D | (E & F)");

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
@@ -4,10 +4,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
-import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;
+import com.mmm.his.cer.utility.farser.ast.setup.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.setup.TestContext;
 import com.mmm.his.cer.utility.farser.lexer.DrgFormulaLexer;
 import com.mmm.his.cer.utility.farser.lexer.drg.DrgLexerToken;

--- a/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
+++ b/src/test/java/com/mmm/his/cer/utility/farser/ast/PrintingTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mmm.his.cer.utility.farser.ast.AbstractSyntaxTreePrinter.AstPrinterContext;
-import com.mmm.his.cer.utility.farser.ast.AstTest.StringOperandSupplier;
+import com.mmm.his.cer.utility.farser.ast.AstEvaluationTest.StringOperandSupplier;
 import com.mmm.his.cer.utility.farser.ast.node.type.Expression;
 import com.mmm.his.cer.utility.farser.ast.parser.DescentParser;
 import com.mmm.his.cer.utility.farser.ast.setup.MaskedContext;


### PR DESCRIPTION
Fixed the iteration for NOT nodes. This would apply for any node which only has one side set and the other side is NULL.

The printer now has an overarching try-catch to provide more context when printing fails.

The iterator throws a more meaningful exception when NULL nodes are encountered.

An implementation of `StringOperandSupplier` is used multiple times in tests. Changed so that the local class implementation is only used in that class and other tests use the public shared implementation.